### PR TITLE
Compile-time branch evaluation --- 25x speedup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -48,4 +48,4 @@ test_kat:
 
 bench_python:
 	make lib
-	cd wrapper/python; python3.10 bench_tinyjambu.py; cd ../..
+	cd wrapper/python; python3 bench_tinyjambu.py; cd ../..

--- a/README.md
+++ b/README.md
@@ -168,55 +168,55 @@ FBK=32 make benchmark
 ```
 
 ```bash
-2022-05-06T13:22:06+05:30
+2022-05-09T10:43:10+05:30
 Running ./bench/a.out
 Run on (4 X 1800 MHz CPU s)
-Load Average: 1.26, 1.60, 1.97
-------------------------------------------------------------------------------------------
-Benchmark                                Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------
-tinyjambu_128_encrypt_64B_32B          214 ns          214 ns      3258175 bytes_per_second=427.413M/s
-tinyjambu_128_decrypt_64B_32B          258 ns          258 ns      2710619 bytes_per_second=355.428M/s
-tinyjambu_128_encrypt_128B_32B         304 ns          304 ns      2300939 bytes_per_second=502.541M/s
-tinyjambu_128_decrypt_128B_32B         382 ns          382 ns      1829325 bytes_per_second=399.145M/s
-tinyjambu_128_encrypt_256B_32B         492 ns          492 ns      1424379 bytes_per_second=558.672M/s
-tinyjambu_128_decrypt_256B_32B         638 ns          638 ns      1091766 bytes_per_second=430.7M/s
-tinyjambu_128_encrypt_512B_32B         847 ns          847 ns       821184 bytes_per_second=612.299M/s
-tinyjambu_128_decrypt_512B_32B        1137 ns         1137 ns       614322 bytes_per_second=456.451M/s
-tinyjambu_128_encrypt_1024B_32B       1561 ns         1560 ns       448022 bytes_per_second=645.468M/s
-tinyjambu_128_decrypt_1024B_32B       2141 ns         2135 ns       327782 bytes_per_second=471.771M/s
-tinyjambu_128_encrypt_2048B_32B       2986 ns         2985 ns       234390 bytes_per_second=664.436M/s
-tinyjambu_128_decrypt_2048B_32B       4130 ns         4129 ns       169542 bytes_per_second=480.452M/s
-tinyjambu_128_encrypt_4096B_32B       5837 ns         5835 ns       119494 bytes_per_second=674.676M/s
-tinyjambu_128_decrypt_4096B_32B       8125 ns         8121 ns        85926 bytes_per_second=484.789M/s
-tinyjambu_192_encrypt_64B_32B          217 ns          217 ns      3223200 bytes_per_second=421.75M/s
-tinyjambu_192_decrypt_64B_32B          259 ns          259 ns      2702900 bytes_per_second=353.56M/s
-tinyjambu_192_encrypt_128B_32B         306 ns          306 ns      2286668 bytes_per_second=498.285M/s
-tinyjambu_192_decrypt_128B_32B         384 ns          383 ns      1825778 bytes_per_second=397.912M/s
-tinyjambu_192_encrypt_256B_32B         494 ns          494 ns      1418283 bytes_per_second=556.397M/s
-tinyjambu_192_decrypt_256B_32B         641 ns          641 ns      1086930 bytes_per_second=428.255M/s
-tinyjambu_192_encrypt_512B_32B         850 ns          850 ns       821175 bytes_per_second=610.506M/s
-tinyjambu_192_decrypt_512B_32B        1139 ns         1139 ns       612299 bytes_per_second=455.361M/s
-tinyjambu_192_encrypt_1024B_32B       1562 ns         1562 ns       446680 bytes_per_second=644.903M/s
-tinyjambu_192_decrypt_1024B_32B       2138 ns         2137 ns       327171 bytes_per_second=471.192M/s
-tinyjambu_192_encrypt_2048B_32B       2987 ns         2986 ns       234165 bytes_per_second=664.25M/s
-tinyjambu_192_decrypt_2048B_32B       4130 ns         4130 ns       169251 bytes_per_second=480.296M/s
-tinyjambu_192_encrypt_4096B_32B       5838 ns         5836 ns       119422 bytes_per_second=674.509M/s
-tinyjambu_192_decrypt_4096B_32B       8128 ns         8125 ns        85811 bytes_per_second=484.551M/s
-tinyjambu_256_encrypt_64B_32B          223 ns          223 ns      3133036 bytes_per_second=409.942M/s
-tinyjambu_256_decrypt_64B_32B          260 ns          260 ns      2684956 bytes_per_second=351.523M/s
-tinyjambu_256_encrypt_128B_32B         307 ns          307 ns      2281623 bytes_per_second=497.543M/s
-tinyjambu_256_decrypt_128B_32B         386 ns          385 ns      1817545 bytes_per_second=395.943M/s
-tinyjambu_256_encrypt_256B_32B         493 ns          493 ns      1419653 bytes_per_second=557.167M/s
-tinyjambu_256_decrypt_256B_32B         641 ns          641 ns      1087613 bytes_per_second=428.347M/s
-tinyjambu_256_encrypt_512B_32B         849 ns          849 ns       821790 bytes_per_second=610.939M/s
-tinyjambu_256_decrypt_512B_32B        1140 ns         1140 ns       612646 bytes_per_second=455.057M/s
-tinyjambu_256_encrypt_1024B_32B       1562 ns         1561 ns       447705 bytes_per_second=645.044M/s
-tinyjambu_256_decrypt_1024B_32B       2137 ns         2136 ns       327512 bytes_per_second=471.37M/s
-tinyjambu_256_encrypt_2048B_32B       2985 ns         2985 ns       233892 bytes_per_second=664.544M/s
-tinyjambu_256_decrypt_2048B_32B       4133 ns         4132 ns       169384 bytes_per_second=480.03M/s
-tinyjambu_256_encrypt_4096B_32B       5836 ns         5835 ns       119364 bytes_per_second=674.731M/s
-tinyjambu_256_decrypt_4096B_32B       8125 ns         8122 ns        85866 bytes_per_second=484.692M/s
+Load Average: 2.62, 3.21, 2.62
+----------------------------------------------------------------------------------------
+Benchmark                              Time             CPU   Iterations UserCounters...
+----------------------------------------------------------------------------------------
+tinyjambu_128_encrypt/64/32          216 ns          214 ns      3182810 bytes_per_second=427.007M/s
+tinyjambu_128_decrypt/64/32          229 ns          223 ns      3176595 bytes_per_second=410.417M/s
+tinyjambu_128_encrypt/128/32         313 ns          312 ns      2226953 bytes_per_second=489.541M/s
+tinyjambu_128_decrypt/128/32         328 ns          322 ns      2177845 bytes_per_second=473.611M/s
+tinyjambu_128_encrypt/256/32         504 ns          491 ns      1415706 bytes_per_second=559.491M/s
+tinyjambu_128_decrypt/256/32         499 ns          499 ns      1403780 bytes_per_second=550.961M/s
+tinyjambu_128_encrypt/512/32         849 ns          849 ns       826057 bytes_per_second=611.308M/s
+tinyjambu_128_decrypt/512/32         856 ns          856 ns       817213 bytes_per_second=606.2M/s
+tinyjambu_128_encrypt/1024/32       1562 ns         1562 ns       447894 bytes_per_second=644.878M/s
+tinyjambu_128_decrypt/1024/32       1570 ns         1570 ns       445427 bytes_per_second=641.444M/s
+tinyjambu_128_encrypt/2048/32       3160 ns         3010 ns       233740 bytes_per_second=659.115M/s
+tinyjambu_128_decrypt/2048/32       3010 ns         3000 ns       231534 bytes_per_second=661.164M/s
+tinyjambu_128_encrypt/4096/32       5839 ns         5835 ns       119589 bytes_per_second=674.664M/s
+tinyjambu_128_decrypt/4096/32       5849 ns         5846 ns       119334 bytes_per_second=673.464M/s
+tinyjambu_192_encrypt/64/32          231 ns          231 ns      3028652 bytes_per_second=396.129M/s
+tinyjambu_192_decrypt/64/32          241 ns          241 ns      2902854 bytes_per_second=379.852M/s
+tinyjambu_192_encrypt/128/32         328 ns          327 ns      2139179 bytes_per_second=465.974M/s
+tinyjambu_192_decrypt/128/32         338 ns          338 ns      2072097 bytes_per_second=451.596M/s
+tinyjambu_192_encrypt/256/32         506 ns          506 ns      1380932 bytes_per_second=543.109M/s
+tinyjambu_192_decrypt/256/32         516 ns          516 ns      1352568 bytes_per_second=532.438M/s
+tinyjambu_192_encrypt/512/32         862 ns          862 ns       810011 bytes_per_second=602.183M/s
+tinyjambu_192_decrypt/512/32         873 ns          873 ns       800428 bytes_per_second=594.592M/s
+tinyjambu_192_encrypt/1024/32       1575 ns         1574 ns       444179 bytes_per_second=639.796M/s
+tinyjambu_192_decrypt/1024/32       1586 ns         1585 ns       441155 bytes_per_second=635.237M/s
+tinyjambu_192_encrypt/2048/32       3000 ns         2999 ns       233440 bytes_per_second=661.404M/s
+tinyjambu_192_decrypt/2048/32       3015 ns         3013 ns       232417 bytes_per_second=658.299M/s
+tinyjambu_192_encrypt/4096/32       5848 ns         5847 ns       119220 bytes_per_second=673.345M/s
+tinyjambu_192_decrypt/4096/32       5862 ns         5860 ns       118927 bytes_per_second=671.799M/s
+tinyjambu_256_encrypt/64/32          215 ns          215 ns      3250097 bytes_per_second=426.069M/s
+tinyjambu_256_decrypt/64/32          221 ns          221 ns      3157166 bytes_per_second=413.467M/s
+tinyjambu_256_encrypt/128/32         313 ns          313 ns      2236083 bytes_per_second=487.729M/s
+tinyjambu_256_decrypt/128/32         319 ns          319 ns      2190362 bytes_per_second=477.855M/s
+tinyjambu_256_encrypt/256/32         491 ns          491 ns      1424632 bytes_per_second=559.742M/s
+tinyjambu_256_decrypt/256/32         498 ns          498 ns      1407189 bytes_per_second=551.76M/s
+tinyjambu_256_encrypt/512/32         847 ns          847 ns       824256 bytes_per_second=612.598M/s
+tinyjambu_256_decrypt/512/32         854 ns          853 ns       817900 bytes_per_second=607.954M/s
+tinyjambu_256_encrypt/1024/32       1561 ns         1560 ns       447668 bytes_per_second=645.549M/s
+tinyjambu_256_decrypt/1024/32       1566 ns         1565 ns       446041 bytes_per_second=643.338M/s
+tinyjambu_256_encrypt/2048/32       2986 ns         2985 ns       234492 bytes_per_second=664.52M/s
+tinyjambu_256_decrypt/2048/32       2991 ns         2991 ns       233925 bytes_per_second=663.251M/s
+tinyjambu_256_encrypt/4096/32       5842 ns         5838 ns       119566 bytes_per_second=674.298M/s
+tinyjambu_256_decrypt/4096/32       5844 ns         5842 ns       119292 bytes_per_second=673.887M/s
 ```
 
 or 
@@ -226,55 +226,55 @@ FBK=128 make benchmark
 ```
 
 ```bash
-2022-05-06T13:25:54+05:30
+2022-05-09T10:44:52+05:30
 Running ./bench/a.out
 Run on (4 X 1800 MHz CPU s)
-Load Average: 0.84, 1.05, 1.66
-------------------------------------------------------------------------------------------
-Benchmark                                Time             CPU   Iterations UserCounters...
-------------------------------------------------------------------------------------------
-tinyjambu_128_encrypt_64B_32B          191 ns          189 ns      3719449 bytes_per_second=484.043M/s
-tinyjambu_128_decrypt_64B_32B          228 ns          227 ns      3097954 bytes_per_second=403.955M/s
-tinyjambu_128_encrypt_128B_32B         299 ns          281 ns      2506384 bytes_per_second=542.858M/s
-tinyjambu_128_decrypt_128B_32B         341 ns          341 ns      2051842 bytes_per_second=447.173M/s
-tinyjambu_128_encrypt_256B_32B         463 ns          463 ns      1512329 bytes_per_second=593.157M/s
-tinyjambu_128_decrypt_256B_32B         582 ns          579 ns      1210753 bytes_per_second=474.037M/s
-tinyjambu_128_encrypt_512B_32B         822 ns          821 ns       845418 bytes_per_second=632.034M/s
-tinyjambu_128_decrypt_512B_32B        1057 ns         1050 ns       668798 bytes_per_second=494.208M/s
-tinyjambu_128_encrypt_1024B_32B       1547 ns         1540 ns       455576 bytes_per_second=653.989M/s
-tinyjambu_128_decrypt_1024B_32B       1989 ns         1972 ns       351060 bytes_per_second=510.669M/s
-tinyjambu_128_encrypt_2048B_32B       3083 ns         3003 ns       236531 bytes_per_second=660.455M/s
-tinyjambu_128_decrypt_2048B_32B       3867 ns         3838 ns       182978 bytes_per_second=516.883M/s
-tinyjambu_128_encrypt_4096B_32B       5916 ns         5846 ns       120283 bytes_per_second=673.424M/s
-tinyjambu_128_decrypt_4096B_32B       7533 ns         7528 ns        92978 bytes_per_second=522.957M/s
-tinyjambu_192_encrypt_64B_32B          192 ns          191 ns      3660487 bytes_per_second=479.165M/s
-tinyjambu_192_decrypt_64B_32B          235 ns          235 ns      2978014 bytes_per_second=389.797M/s
-tinyjambu_192_encrypt_128B_32B         280 ns          279 ns      2503782 bytes_per_second=545.94M/s
-tinyjambu_192_decrypt_128B_32B         360 ns          360 ns      1946667 bytes_per_second=424.289M/s
-tinyjambu_192_encrypt_256B_32B         467 ns          466 ns      1501211 bytes_per_second=588.918M/s
-tinyjambu_192_decrypt_256B_32B         615 ns          615 ns      1133446 bytes_per_second=446.529M/s
-tinyjambu_192_encrypt_512B_32B         823 ns          823 ns       848092 bytes_per_second=630.676M/s
-tinyjambu_192_decrypt_512B_32B        1114 ns         1114 ns       626909 bytes_per_second=465.849M/s
-tinyjambu_192_encrypt_1024B_32B       1534 ns         1534 ns       455510 bytes_per_second=656.435M/s
-tinyjambu_192_decrypt_1024B_32B       2111 ns         2111 ns       330364 bytes_per_second=477.174M/s
-tinyjambu_192_encrypt_2048B_32B       2959 ns         2958 ns       236145 bytes_per_second=670.514M/s
-tinyjambu_192_decrypt_2048B_32B       4105 ns         4105 ns       170318 bytes_per_second=483.258M/s
-tinyjambu_192_encrypt_4096B_32B       5807 ns         5807 ns       120118 bytes_per_second=677.962M/s
-tinyjambu_192_decrypt_4096B_32B       8100 ns         8097 ns        86294 bytes_per_second=486.2M/s
-tinyjambu_256_encrypt_64B_32B          190 ns          190 ns      3674394 bytes_per_second=480.861M/s
-tinyjambu_256_decrypt_64B_32B          235 ns          234 ns      2983217 bytes_per_second=390.584M/s
-tinyjambu_256_encrypt_128B_32B         281 ns          280 ns      2495984 bytes_per_second=544.037M/s
-tinyjambu_256_decrypt_128B_32B         359 ns          359 ns      1950381 bytes_per_second=425.006M/s
-tinyjambu_256_encrypt_256B_32B         465 ns          465 ns      1503744 bytes_per_second=590.527M/s
-tinyjambu_256_decrypt_256B_32B         615 ns          614 ns      1133454 bytes_per_second=446.968M/s
-tinyjambu_256_encrypt_512B_32B         822 ns          821 ns       849130 bytes_per_second=631.543M/s
-tinyjambu_256_decrypt_512B_32B        1114 ns         1113 ns       627237 bytes_per_second=466.045M/s
-tinyjambu_256_encrypt_1024B_32B       1533 ns         1533 ns       455629 bytes_per_second=656.905M/s
-tinyjambu_256_decrypt_1024B_32B       2110 ns         2109 ns       331333 bytes_per_second=477.414M/s
-tinyjambu_256_encrypt_2048B_32B       2958 ns         2957 ns       236159 bytes_per_second=670.757M/s
-tinyjambu_256_decrypt_2048B_32B       4109 ns         4107 ns       170346 bytes_per_second=482.966M/s
-tinyjambu_256_encrypt_4096B_32B       5806 ns         5806 ns       119779 bytes_per_second=678.094M/s
-tinyjambu_256_decrypt_4096B_32B       8100 ns         8096 ns        86107 bytes_per_second=486.235M/s
+Load Average: 2.14, 2.91, 2.57
+----------------------------------------------------------------------------------------
+Benchmark                              Time             CPU   Iterations UserCounters...
+----------------------------------------------------------------------------------------
+tinyjambu_128_encrypt/64/32          193 ns          191 ns      3641451 bytes_per_second=480.273M/s
+tinyjambu_128_decrypt/64/32          201 ns          198 ns      3558422 bytes_per_second=463.242M/s
+tinyjambu_128_encrypt/128/32         292 ns          286 ns      2462547 bytes_per_second=533.676M/s
+tinyjambu_128_decrypt/128/32         291 ns          291 ns      2400488 bytes_per_second=525.116M/s
+tinyjambu_128_encrypt/256/32         478 ns          469 ns      1508424 bytes_per_second=586.072M/s
+tinyjambu_128_decrypt/256/32         475 ns          474 ns      1448338 bytes_per_second=579.215M/s
+tinyjambu_128_encrypt/512/32         833 ns          826 ns       841159 bytes_per_second=628.288M/s
+tinyjambu_128_decrypt/512/32         853 ns          840 ns       829213 bytes_per_second=617.852M/s
+tinyjambu_128_encrypt/1024/32       1623 ns         1553 ns       456523 bytes_per_second=648.398M/s
+tinyjambu_128_decrypt/1024/32       1559 ns         1548 ns       450491 bytes_per_second=650.563M/s
+tinyjambu_128_encrypt/2048/32       2988 ns         2971 ns       233836 bytes_per_second=667.718M/s
+tinyjambu_128_decrypt/2048/32       3093 ns         2995 ns       235562 bytes_per_second=662.317M/s
+tinyjambu_128_encrypt/4096/32       5916 ns         5861 ns       119073 bytes_per_second=671.728M/s
+tinyjambu_128_decrypt/4096/32       5817 ns         5814 ns       119346 bytes_per_second=677.112M/s
+tinyjambu_192_encrypt/64/32          188 ns          188 ns      3724889 bytes_per_second=487.983M/s
+tinyjambu_192_decrypt/64/32          196 ns          196 ns      3552895 bytes_per_second=466.802M/s
+tinyjambu_192_encrypt/128/32         286 ns          286 ns      2446996 bytes_per_second=533.318M/s
+tinyjambu_192_decrypt/128/32         293 ns          293 ns      2389541 bytes_per_second=521.086M/s
+tinyjambu_192_encrypt/256/32         464 ns          464 ns      1507097 bytes_per_second=591.852M/s
+tinyjambu_192_decrypt/256/32         471 ns          471 ns      1485882 bytes_per_second=583.323M/s
+tinyjambu_192_encrypt/512/32         820 ns          820 ns       850925 bytes_per_second=632.669M/s
+tinyjambu_192_decrypt/512/32         828 ns          827 ns       844401 bytes_per_second=627.072M/s
+tinyjambu_192_encrypt/1024/32       1533 ns         1533 ns       456060 bytes_per_second=657.011M/s
+tinyjambu_192_decrypt/1024/32       1541 ns         1540 ns       453892 bytes_per_second=653.872M/s
+tinyjambu_192_encrypt/2048/32       2964 ns         2962 ns       236348 bytes_per_second=669.619M/s
+tinyjambu_192_decrypt/2048/32       2967 ns         2966 ns       235909 bytes_per_second=668.893M/s
+tinyjambu_192_encrypt/4096/32       5812 ns         5808 ns       119998 bytes_per_second=677.765M/s
+tinyjambu_192_decrypt/4096/32       5818 ns         5816 ns       119841 bytes_per_second=676.898M/s
+tinyjambu_256_encrypt/64/32          186 ns          186 ns      3743209 bytes_per_second=491.209M/s
+tinyjambu_256_decrypt/64/32          194 ns          194 ns      3603944 bytes_per_second=472.872M/s
+tinyjambu_256_encrypt/128/32         285 ns          285 ns      2449205 bytes_per_second=534.658M/s
+tinyjambu_256_decrypt/128/32         291 ns          291 ns      2400698 bytes_per_second=524.439M/s
+tinyjambu_256_encrypt/256/32         464 ns          464 ns      1508813 bytes_per_second=592.532M/s
+tinyjambu_256_decrypt/256/32         470 ns          469 ns      1491662 bytes_per_second=585.198M/s
+tinyjambu_256_encrypt/512/32         820 ns          820 ns       851391 bytes_per_second=632.875M/s
+tinyjambu_256_decrypt/512/32         825 ns          825 ns       844338 bytes_per_second=628.799M/s
+tinyjambu_256_encrypt/1024/32       1533 ns         1532 ns       456028 bytes_per_second=657.202M/s
+tinyjambu_256_decrypt/1024/32       1539 ns         1538 ns       454670 bytes_per_second=654.627M/s
+tinyjambu_256_encrypt/2048/32       2959 ns         2958 ns       236706 bytes_per_second=670.618M/s
+tinyjambu_256_decrypt/2048/32       2966 ns         2964 ns       236129 bytes_per_second=669.179M/s
+tinyjambu_256_encrypt/4096/32       5811 ns         5808 ns       120053 bytes_per_second=677.848M/s
+tinyjambu_256_decrypt/4096/32       5820 ns         5817 ns       119927 bytes_per_second=676.767M/s
 ```
 
 > Not mentioning any value for `FBK` parameter, results in setting `FBK=32` !
@@ -286,7 +286,7 @@ FBK=32 make bench_python
 ```
 
 ```bash
-2022-05-06T08:53:50+00:00
+2022-05-09T05:20:22+00:00
 Running bench_tinyjambu.py
 Run on (4 X 2300 MHz CPU s)
 CPU Caches:
@@ -294,16 +294,16 @@ CPU Caches:
   L1 Instruction 32 KiB (x2)
   L2 Unified 256 KiB (x2)
   L3 Unified 46080 KiB (x1)
-Load Average: 0.23, 0.23, 0.12
+Load Average: 0.14, 0.03, 0.01
 ----------------------------------------------------------------
 Benchmark                      Time             CPU   Iterations
 ----------------------------------------------------------------
-tinyjambu_128_encrypt      35807 ns        35806 ns        19346
-tinyjambu_128_decrypt      36383 ns        36381 ns        19390
-tinyjambu_192_encrypt      36396 ns        36395 ns        19260
-tinyjambu_192_decrypt      36662 ns        36657 ns        19093
-tinyjambu_256_encrypt      36532 ns        36529 ns        19344
-tinyjambu_256_decrypt      35906 ns        35902 ns        19545
+tinyjambu_128_encrypt      36198 ns        36198 ns        19178
+tinyjambu_128_decrypt      36955 ns        36954 ns        19055
+tinyjambu_192_encrypt      36808 ns        36808 ns        19155
+tinyjambu_192_decrypt      37485 ns        37483 ns        18694
+tinyjambu_256_encrypt      37357 ns        37355 ns        18879
+tinyjambu_256_decrypt      36487 ns        36486 ns        19137
 ```
 
 or when interested in computing 128 feedback bits each iteration
@@ -313,7 +313,7 @@ FBK=128 make bench_python
 ```
 
 ```bash
-2022-05-06T08:53:14+00:00
+2022-05-09T05:21:00+00:00
 Running bench_tinyjambu.py
 Run on (4 X 2300 MHz CPU s)
 CPU Caches:
@@ -321,16 +321,16 @@ CPU Caches:
   L1 Instruction 32 KiB (x2)
   L2 Unified 256 KiB (x2)
   L3 Unified 46080 KiB (x1)
-Load Average: 0.11, 0.22, 0.11
+Load Average: 0.13, 0.04, 0.01
 ----------------------------------------------------------------
 Benchmark                      Time             CPU   Iterations
 ----------------------------------------------------------------
-tinyjambu_128_encrypt      36252 ns        36248 ns        19124
-tinyjambu_128_decrypt      36922 ns        36919 ns        19136
-tinyjambu_192_encrypt      36976 ns        36974 ns        19086
-tinyjambu_192_decrypt      37122 ns        37120 ns        18719
-tinyjambu_256_encrypt      36729 ns        36730 ns        19045
-tinyjambu_256_decrypt      36435 ns        36433 ns        19436
+tinyjambu_128_encrypt      35533 ns        35530 ns        19457
+tinyjambu_128_decrypt      36372 ns        36367 ns        19464
+tinyjambu_192_encrypt      36386 ns        36385 ns        19260
+tinyjambu_192_decrypt      36435 ns        36430 ns        19160
+tinyjambu_256_encrypt      36534 ns        36534 ns        19196
+tinyjambu_256_decrypt      35389 ns        35388 ns        19920
 ```
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -168,55 +168,55 @@ FBK=32 make benchmark
 ```
 
 ```bash
-2022-04-26T20:35:01+05:30
+2022-05-06T13:22:06+05:30
 Running ./bench/a.out
 Run on (4 X 1800 MHz CPU s)
-Load Average: 0.96, 1.06, 0.59
+Load Average: 1.26, 1.60, 1.97
 ------------------------------------------------------------------------------------------
 Benchmark                                Time             CPU   Iterations UserCounters...
 ------------------------------------------------------------------------------------------
-tinyjambu_128_encrypt_64B_32B         4215 ns         4214 ns       166119 bytes_per_second=21.7237M/s items_per_second=237.28k/s
-tinyjambu_128_encrypt_128B_32B        6809 ns         6809 ns       102635 bytes_per_second=22.4105M/s items_per_second=146.87k/s
-tinyjambu_128_encrypt_256B_32B       12153 ns        12090 ns        58248 bytes_per_second=22.7173M/s items_per_second=82.7113k/s
-tinyjambu_128_encrypt_512B_32B       22434 ns        22420 ns        31176 bytes_per_second=23.1401M/s items_per_second=44.6032k/s
-tinyjambu_128_encrypt_1024B_32B      43237 ns        43212 ns        16193 bytes_per_second=23.3057M/s items_per_second=23.1418k/s
-tinyjambu_128_encrypt_2048B_32B      84846 ns        84804 ns         8228 bytes_per_second=23.3908M/s items_per_second=11.7919k/s
-tinyjambu_128_encrypt_4096B_32B     168406 ns       168228 ns         4155 bytes_per_second=23.4013M/s items_per_second=5.9443k/s
-tinyjambu_192_encrypt_64B_32B         4475 ns         4472 ns       156526 bytes_per_second=20.4713M/s items_per_second=223.601k/s
-tinyjambu_192_encrypt_128B_32B        7390 ns         7383 ns        94506 bytes_per_second=20.668M/s items_per_second=135.45k/s
-tinyjambu_192_encrypt_256B_32B       13161 ns        13154 ns        53144 bytes_per_second=20.8808M/s items_per_second=76.0247k/s
-tinyjambu_192_encrypt_512B_32B       24621 ns        24613 ns        28429 bytes_per_second=21.0783M/s items_per_second=40.6291k/s
-tinyjambu_192_encrypt_1024B_32B      47646 ns        47629 ns        14699 bytes_per_second=21.1441M/s items_per_second=20.9955k/s
-tinyjambu_192_encrypt_2048B_32B      93717 ns        93659 ns         7455 bytes_per_second=21.1795M/s items_per_second=10.6771k/s
-tinyjambu_192_encrypt_4096B_32B     185729 ns       185659 ns         3767 bytes_per_second=21.2043M/s items_per_second=5.38622k/s
-tinyjambu_256_encrypt_64B_32B         5111 ns         5111 ns       136325 bytes_per_second=17.9146M/s items_per_second=195.675k/s
-tinyjambu_256_encrypt_128B_32B        8521 ns         8518 ns        81827 bytes_per_second=17.9129M/s items_per_second=117.394k/s
-tinyjambu_256_encrypt_256B_32B       15340 ns        15335 ns        45570 bytes_per_second=17.9102M/s items_per_second=65.2089k/s
-tinyjambu_256_encrypt_512B_32B       28906 ns        28897 ns        24212 bytes_per_second=17.9531M/s items_per_second=34.6052k/s
-tinyjambu_256_encrypt_1024B_32B      56131 ns        56110 ns        12422 bytes_per_second=17.9483M/s items_per_second=17.8221k/s
-tinyjambu_256_encrypt_2048B_32B     110598 ns       110551 ns         6321 bytes_per_second=17.9432M/s items_per_second=9.04559k/s
-tinyjambu_256_encrypt_4096B_32B     219481 ns       219395 ns         3191 bytes_per_second=17.9437M/s items_per_second=4.55798k/s
-tinyjambu_128_decrypt_64B_32B         4223 ns         4221 ns       165910 bytes_per_second=21.6887M/s items_per_second=236.899k/s
-tinyjambu_128_decrypt_128B_32B        6817 ns         6814 ns       102220 bytes_per_second=22.3917M/s items_per_second=146.746k/s
-tinyjambu_128_decrypt_256B_32B       11998 ns        11996 ns        58113 bytes_per_second=22.8953M/s items_per_second=83.3591k/s
-tinyjambu_128_decrypt_512B_32B       22388 ns        22385 ns        31228 bytes_per_second=23.1766M/s items_per_second=44.6737k/s
-tinyjambu_128_decrypt_1024B_32B      43145 ns        43138 ns        16215 bytes_per_second=23.3453M/s items_per_second=23.1812k/s
-tinyjambu_128_decrypt_2048B_32B      84693 ns        84671 ns         8221 bytes_per_second=23.4276M/s items_per_second=11.8104k/s
-tinyjambu_128_decrypt_4096B_32B     167800 ns       167737 ns         4171 bytes_per_second=23.4699M/s items_per_second=5.96171k/s
-tinyjambu_192_decrypt_64B_32B         4543 ns         4542 ns       154000 bytes_per_second=20.1565M/s items_per_second=220.163k/s
-tinyjambu_192_decrypt_128B_32B        7412 ns         7409 ns        94132 bytes_per_second=20.5949M/s items_per_second=134.971k/s
-tinyjambu_192_decrypt_256B_32B       13168 ns        13164 ns        53066 bytes_per_second=20.865M/s items_per_second=75.9673k/s
-tinyjambu_192_decrypt_512B_32B       24672 ns        24663 ns        28363 bytes_per_second=21.0354M/s items_per_second=40.5464k/s
-tinyjambu_192_decrypt_1024B_32B      47550 ns        47532 ns        14731 bytes_per_second=21.1873M/s items_per_second=21.0383k/s
-tinyjambu_192_decrypt_2048B_32B      93716 ns        93683 ns         7439 bytes_per_second=21.174M/s items_per_second=10.6743k/s
-tinyjambu_192_decrypt_4096B_32B     185200 ns       185133 ns         3778 bytes_per_second=21.2645M/s items_per_second=5.40152k/s
-tinyjambu_256_decrypt_64B_32B         5107 ns         5105 ns       136495 bytes_per_second=17.9344M/s items_per_second=195.891k/s
-tinyjambu_256_decrypt_128B_32B        8521 ns         8520 ns        81836 bytes_per_second=17.9101M/s items_per_second=117.376k/s
-tinyjambu_256_decrypt_256B_32B       15356 ns        15353 ns        45496 bytes_per_second=17.889M/s items_per_second=65.1319k/s
-tinyjambu_256_decrypt_512B_32B       28977 ns        28974 ns        24129 bytes_per_second=17.9058M/s items_per_second=34.5139k/s
-tinyjambu_256_decrypt_1024B_32B      56448 ns        56427 ns        12350 bytes_per_second=17.8476M/s items_per_second=17.7222k/s
-tinyjambu_256_decrypt_2048B_32B     111090 ns       111001 ns         6303 bytes_per_second=17.8705M/s items_per_second=9.00893k/s
-tinyjambu_256_decrypt_4096B_32B     220698 ns       220582 ns         3173 bytes_per_second=17.8471M/s items_per_second=4.53345k/s
+tinyjambu_128_encrypt_64B_32B          214 ns          214 ns      3258175 bytes_per_second=427.413M/s
+tinyjambu_128_decrypt_64B_32B          258 ns          258 ns      2710619 bytes_per_second=355.428M/s
+tinyjambu_128_encrypt_128B_32B         304 ns          304 ns      2300939 bytes_per_second=502.541M/s
+tinyjambu_128_decrypt_128B_32B         382 ns          382 ns      1829325 bytes_per_second=399.145M/s
+tinyjambu_128_encrypt_256B_32B         492 ns          492 ns      1424379 bytes_per_second=558.672M/s
+tinyjambu_128_decrypt_256B_32B         638 ns          638 ns      1091766 bytes_per_second=430.7M/s
+tinyjambu_128_encrypt_512B_32B         847 ns          847 ns       821184 bytes_per_second=612.299M/s
+tinyjambu_128_decrypt_512B_32B        1137 ns         1137 ns       614322 bytes_per_second=456.451M/s
+tinyjambu_128_encrypt_1024B_32B       1561 ns         1560 ns       448022 bytes_per_second=645.468M/s
+tinyjambu_128_decrypt_1024B_32B       2141 ns         2135 ns       327782 bytes_per_second=471.771M/s
+tinyjambu_128_encrypt_2048B_32B       2986 ns         2985 ns       234390 bytes_per_second=664.436M/s
+tinyjambu_128_decrypt_2048B_32B       4130 ns         4129 ns       169542 bytes_per_second=480.452M/s
+tinyjambu_128_encrypt_4096B_32B       5837 ns         5835 ns       119494 bytes_per_second=674.676M/s
+tinyjambu_128_decrypt_4096B_32B       8125 ns         8121 ns        85926 bytes_per_second=484.789M/s
+tinyjambu_192_encrypt_64B_32B          217 ns          217 ns      3223200 bytes_per_second=421.75M/s
+tinyjambu_192_decrypt_64B_32B          259 ns          259 ns      2702900 bytes_per_second=353.56M/s
+tinyjambu_192_encrypt_128B_32B         306 ns          306 ns      2286668 bytes_per_second=498.285M/s
+tinyjambu_192_decrypt_128B_32B         384 ns          383 ns      1825778 bytes_per_second=397.912M/s
+tinyjambu_192_encrypt_256B_32B         494 ns          494 ns      1418283 bytes_per_second=556.397M/s
+tinyjambu_192_decrypt_256B_32B         641 ns          641 ns      1086930 bytes_per_second=428.255M/s
+tinyjambu_192_encrypt_512B_32B         850 ns          850 ns       821175 bytes_per_second=610.506M/s
+tinyjambu_192_decrypt_512B_32B        1139 ns         1139 ns       612299 bytes_per_second=455.361M/s
+tinyjambu_192_encrypt_1024B_32B       1562 ns         1562 ns       446680 bytes_per_second=644.903M/s
+tinyjambu_192_decrypt_1024B_32B       2138 ns         2137 ns       327171 bytes_per_second=471.192M/s
+tinyjambu_192_encrypt_2048B_32B       2987 ns         2986 ns       234165 bytes_per_second=664.25M/s
+tinyjambu_192_decrypt_2048B_32B       4130 ns         4130 ns       169251 bytes_per_second=480.296M/s
+tinyjambu_192_encrypt_4096B_32B       5838 ns         5836 ns       119422 bytes_per_second=674.509M/s
+tinyjambu_192_decrypt_4096B_32B       8128 ns         8125 ns        85811 bytes_per_second=484.551M/s
+tinyjambu_256_encrypt_64B_32B          223 ns          223 ns      3133036 bytes_per_second=409.942M/s
+tinyjambu_256_decrypt_64B_32B          260 ns          260 ns      2684956 bytes_per_second=351.523M/s
+tinyjambu_256_encrypt_128B_32B         307 ns          307 ns      2281623 bytes_per_second=497.543M/s
+tinyjambu_256_decrypt_128B_32B         386 ns          385 ns      1817545 bytes_per_second=395.943M/s
+tinyjambu_256_encrypt_256B_32B         493 ns          493 ns      1419653 bytes_per_second=557.167M/s
+tinyjambu_256_decrypt_256B_32B         641 ns          641 ns      1087613 bytes_per_second=428.347M/s
+tinyjambu_256_encrypt_512B_32B         849 ns          849 ns       821790 bytes_per_second=610.939M/s
+tinyjambu_256_decrypt_512B_32B        1140 ns         1140 ns       612646 bytes_per_second=455.057M/s
+tinyjambu_256_encrypt_1024B_32B       1562 ns         1561 ns       447705 bytes_per_second=645.044M/s
+tinyjambu_256_decrypt_1024B_32B       2137 ns         2136 ns       327512 bytes_per_second=471.37M/s
+tinyjambu_256_encrypt_2048B_32B       2985 ns         2985 ns       233892 bytes_per_second=664.544M/s
+tinyjambu_256_decrypt_2048B_32B       4133 ns         4132 ns       169384 bytes_per_second=480.03M/s
+tinyjambu_256_encrypt_4096B_32B       5836 ns         5835 ns       119364 bytes_per_second=674.731M/s
+tinyjambu_256_decrypt_4096B_32B       8125 ns         8122 ns        85866 bytes_per_second=484.692M/s
 ```
 
 or 
@@ -226,55 +226,55 @@ FBK=128 make benchmark
 ```
 
 ```bash
-2022-04-26T20:35:56+05:30
+2022-05-06T13:25:54+05:30
 Running ./bench/a.out
 Run on (4 X 1800 MHz CPU s)
-Load Average: 1.05, 1.06, 0.62
+Load Average: 0.84, 1.05, 1.66
 ------------------------------------------------------------------------------------------
 Benchmark                                Time             CPU   Iterations UserCounters...
 ------------------------------------------------------------------------------------------
-tinyjambu_128_encrypt_64B_32B         3005 ns         3003 ns       232903 bytes_per_second=30.4835M/s items_per_second=332.961k/s
-tinyjambu_128_encrypt_128B_32B        4855 ns         4852 ns       144324 bytes_per_second=31.4466M/s items_per_second=206.088k/s
-tinyjambu_128_encrypt_256B_32B        8576 ns         8566 ns        81475 bytes_per_second=32.0624M/s items_per_second=116.736k/s
-tinyjambu_128_encrypt_512B_32B       15961 ns        15958 ns        43806 bytes_per_second=32.51M/s items_per_second=62.664k/s
-tinyjambu_128_encrypt_1024B_32B      30774 ns        30770 ns        22732 bytes_per_second=32.7298M/s items_per_second=32.4997k/s
-tinyjambu_128_encrypt_2048B_32B      60453 ns        60422 ns        11537 bytes_per_second=32.8297M/s items_per_second=16.5502k/s
-tinyjambu_128_encrypt_4096B_32B     119725 ns       119672 ns         5837 bytes_per_second=32.8962M/s items_per_second=8.35614k/s
-tinyjambu_192_encrypt_64B_32B         3410 ns         3409 ns       205325 bytes_per_second=26.8574M/s items_per_second=293.355k/s
-tinyjambu_192_encrypt_128B_32B        5481 ns         5478 ns       127289 bytes_per_second=27.8537M/s items_per_second=182.542k/s
-tinyjambu_192_encrypt_256B_32B        9648 ns         9645 ns        72399 bytes_per_second=28.4768M/s items_per_second=103.681k/s
-tinyjambu_192_encrypt_512B_32B       17987 ns        17980 ns        38876 bytes_per_second=28.8536M/s items_per_second=55.6161k/s
-tinyjambu_192_encrypt_1024B_32B      34681 ns        34665 ns        20197 bytes_per_second=29.052M/s items_per_second=28.8478k/s
-tinyjambu_192_encrypt_2048B_32B      68008 ns        67997 ns        10264 bytes_per_second=29.1726M/s items_per_second=14.7066k/s
-tinyjambu_192_encrypt_4096B_32B     134733 ns       134712 ns         5180 bytes_per_second=29.2237M/s items_per_second=7.42327k/s
-tinyjambu_256_encrypt_64B_32B         3463 ns         3463 ns       201906 bytes_per_second=26.4397M/s items_per_second=288.792k/s
-tinyjambu_256_encrypt_128B_32B        5640 ns         5637 ns       123635 bytes_per_second=27.0697M/s items_per_second=177.404k/s
-tinyjambu_256_encrypt_256B_32B        9983 ns         9980 ns        69865 bytes_per_second=27.5207M/s items_per_second=100.2k/s
-tinyjambu_256_encrypt_512B_32B       18678 ns        18671 ns        37453 bytes_per_second=27.7867M/s items_per_second=53.5596k/s
-tinyjambu_256_encrypt_1024B_32B      36061 ns        36049 ns        19404 bytes_per_second=27.9363M/s items_per_second=27.7399k/s
-tinyjambu_256_encrypt_2048B_32B      70840 ns        70813 ns         9851 bytes_per_second=28.0123M/s items_per_second=14.1217k/s
-tinyjambu_256_encrypt_4096B_32B     140363 ns       140315 ns         4975 bytes_per_second=28.0566M/s items_per_second=7.1268k/s
-tinyjambu_128_decrypt_64B_32B         3019 ns         3018 ns       231971 bytes_per_second=30.3375M/s items_per_second=331.367k/s
-tinyjambu_128_decrypt_128B_32B        4871 ns         4869 ns       143809 bytes_per_second=31.3356M/s items_per_second=205.361k/s
-tinyjambu_128_decrypt_256B_32B        8576 ns         8573 ns        81408 bytes_per_second=32.0378M/s items_per_second=116.646k/s
-tinyjambu_128_decrypt_512B_32B       15986 ns        15980 ns        43743 bytes_per_second=32.465M/s items_per_second=62.5772k/s
-tinyjambu_128_decrypt_1024B_32B      30808 ns        30795 ns        22714 bytes_per_second=32.7024M/s items_per_second=32.4725k/s
-tinyjambu_128_decrypt_2048B_32B      60419 ns        60409 ns        11534 bytes_per_second=32.8366M/s items_per_second=16.5537k/s
-tinyjambu_128_decrypt_4096B_32B     119736 ns       119695 ns         5835 bytes_per_second=32.8899M/s items_per_second=8.35456k/s
-tinyjambu_192_decrypt_64B_32B         3631 ns         3630 ns       192712 bytes_per_second=25.2201M/s items_per_second=275.471k/s
-tinyjambu_192_decrypt_128B_32B        5488 ns         5485 ns       127072 bytes_per_second=27.8175M/s items_per_second=182.305k/s
-tinyjambu_192_decrypt_256B_32B       10578 ns        10572 ns        66078 bytes_per_second=25.98M/s items_per_second=94.5904k/s
-tinyjambu_192_decrypt_512B_32B       19836 ns        19830 ns        35232 bytes_per_second=26.1619M/s items_per_second=50.4278k/s
-tinyjambu_192_decrypt_1024B_32B      38378 ns        38357 ns        18257 bytes_per_second=26.2553M/s items_per_second=26.0707k/s
-tinyjambu_192_decrypt_2048B_32B      75404 ns        75382 ns         9246 bytes_per_second=26.3147M/s items_per_second=13.2658k/s
-tinyjambu_192_decrypt_4096B_32B     134789 ns       134739 ns         5189 bytes_per_second=29.2177M/s items_per_second=7.42175k/s
-tinyjambu_256_decrypt_64B_32B         3468 ns         3467 ns       201869 bytes_per_second=26.4071M/s items_per_second=288.436k/s
-tinyjambu_256_decrypt_128B_32B        5639 ns         5638 ns       123621 bytes_per_second=27.0637M/s items_per_second=177.365k/s
-tinyjambu_256_decrypt_256B_32B        9986 ns         9983 ns        69786 bytes_per_second=27.5122M/s items_per_second=100.169k/s
-tinyjambu_256_decrypt_512B_32B       18679 ns        18673 ns        37466 bytes_per_second=27.7833M/s items_per_second=53.5531k/s
-tinyjambu_256_decrypt_1024B_32B      36058 ns        36049 ns        19404 bytes_per_second=27.9368M/s items_per_second=27.7404k/s
-tinyjambu_256_decrypt_2048B_32B      70835 ns        70810 ns         9853 bytes_per_second=28.0136M/s items_per_second=14.1223k/s
-tinyjambu_256_decrypt_4096B_32B     140386 ns       140327 ns         4977 bytes_per_second=28.0542M/s items_per_second=7.12621k/s
+tinyjambu_128_encrypt_64B_32B          191 ns          189 ns      3719449 bytes_per_second=484.043M/s
+tinyjambu_128_decrypt_64B_32B          228 ns          227 ns      3097954 bytes_per_second=403.955M/s
+tinyjambu_128_encrypt_128B_32B         299 ns          281 ns      2506384 bytes_per_second=542.858M/s
+tinyjambu_128_decrypt_128B_32B         341 ns          341 ns      2051842 bytes_per_second=447.173M/s
+tinyjambu_128_encrypt_256B_32B         463 ns          463 ns      1512329 bytes_per_second=593.157M/s
+tinyjambu_128_decrypt_256B_32B         582 ns          579 ns      1210753 bytes_per_second=474.037M/s
+tinyjambu_128_encrypt_512B_32B         822 ns          821 ns       845418 bytes_per_second=632.034M/s
+tinyjambu_128_decrypt_512B_32B        1057 ns         1050 ns       668798 bytes_per_second=494.208M/s
+tinyjambu_128_encrypt_1024B_32B       1547 ns         1540 ns       455576 bytes_per_second=653.989M/s
+tinyjambu_128_decrypt_1024B_32B       1989 ns         1972 ns       351060 bytes_per_second=510.669M/s
+tinyjambu_128_encrypt_2048B_32B       3083 ns         3003 ns       236531 bytes_per_second=660.455M/s
+tinyjambu_128_decrypt_2048B_32B       3867 ns         3838 ns       182978 bytes_per_second=516.883M/s
+tinyjambu_128_encrypt_4096B_32B       5916 ns         5846 ns       120283 bytes_per_second=673.424M/s
+tinyjambu_128_decrypt_4096B_32B       7533 ns         7528 ns        92978 bytes_per_second=522.957M/s
+tinyjambu_192_encrypt_64B_32B          192 ns          191 ns      3660487 bytes_per_second=479.165M/s
+tinyjambu_192_decrypt_64B_32B          235 ns          235 ns      2978014 bytes_per_second=389.797M/s
+tinyjambu_192_encrypt_128B_32B         280 ns          279 ns      2503782 bytes_per_second=545.94M/s
+tinyjambu_192_decrypt_128B_32B         360 ns          360 ns      1946667 bytes_per_second=424.289M/s
+tinyjambu_192_encrypt_256B_32B         467 ns          466 ns      1501211 bytes_per_second=588.918M/s
+tinyjambu_192_decrypt_256B_32B         615 ns          615 ns      1133446 bytes_per_second=446.529M/s
+tinyjambu_192_encrypt_512B_32B         823 ns          823 ns       848092 bytes_per_second=630.676M/s
+tinyjambu_192_decrypt_512B_32B        1114 ns         1114 ns       626909 bytes_per_second=465.849M/s
+tinyjambu_192_encrypt_1024B_32B       1534 ns         1534 ns       455510 bytes_per_second=656.435M/s
+tinyjambu_192_decrypt_1024B_32B       2111 ns         2111 ns       330364 bytes_per_second=477.174M/s
+tinyjambu_192_encrypt_2048B_32B       2959 ns         2958 ns       236145 bytes_per_second=670.514M/s
+tinyjambu_192_decrypt_2048B_32B       4105 ns         4105 ns       170318 bytes_per_second=483.258M/s
+tinyjambu_192_encrypt_4096B_32B       5807 ns         5807 ns       120118 bytes_per_second=677.962M/s
+tinyjambu_192_decrypt_4096B_32B       8100 ns         8097 ns        86294 bytes_per_second=486.2M/s
+tinyjambu_256_encrypt_64B_32B          190 ns          190 ns      3674394 bytes_per_second=480.861M/s
+tinyjambu_256_decrypt_64B_32B          235 ns          234 ns      2983217 bytes_per_second=390.584M/s
+tinyjambu_256_encrypt_128B_32B         281 ns          280 ns      2495984 bytes_per_second=544.037M/s
+tinyjambu_256_decrypt_128B_32B         359 ns          359 ns      1950381 bytes_per_second=425.006M/s
+tinyjambu_256_encrypt_256B_32B         465 ns          465 ns      1503744 bytes_per_second=590.527M/s
+tinyjambu_256_decrypt_256B_32B         615 ns          614 ns      1133454 bytes_per_second=446.968M/s
+tinyjambu_256_encrypt_512B_32B         822 ns          821 ns       849130 bytes_per_second=631.543M/s
+tinyjambu_256_decrypt_512B_32B        1114 ns         1113 ns       627237 bytes_per_second=466.045M/s
+tinyjambu_256_encrypt_1024B_32B       1533 ns         1533 ns       455629 bytes_per_second=656.905M/s
+tinyjambu_256_decrypt_1024B_32B       2110 ns         2109 ns       331333 bytes_per_second=477.414M/s
+tinyjambu_256_encrypt_2048B_32B       2958 ns         2957 ns       236159 bytes_per_second=670.757M/s
+tinyjambu_256_decrypt_2048B_32B       4109 ns         4107 ns       170346 bytes_per_second=482.966M/s
+tinyjambu_256_encrypt_4096B_32B       5806 ns         5806 ns       119779 bytes_per_second=678.094M/s
+tinyjambu_256_decrypt_4096B_32B       8100 ns         8096 ns        86107 bytes_per_second=486.235M/s
 ```
 
 > Not mentioning any value for `FBK` parameter, results in setting `FBK=32` !
@@ -286,24 +286,24 @@ FBK=32 make bench_python
 ```
 
 ```bash
-2022-04-28T12:57:04+05:30
+2022-05-06T08:53:50+00:00
 Running bench_tinyjambu.py
-Run on (4 X 1897.34 MHz CPU s)
+Run on (4 X 2300 MHz CPU s)
 CPU Caches:
   L1 Data 32 KiB (x2)
   L1 Instruction 32 KiB (x2)
   L2 Unified 256 KiB (x2)
-  L3 Unified 3072 KiB (x1)
-Load Average: 0.46, 0.45, 0.40
+  L3 Unified 46080 KiB (x1)
+Load Average: 0.23, 0.23, 0.12
 ----------------------------------------------------------------
 Benchmark                      Time             CPU   Iterations
 ----------------------------------------------------------------
-tinyjambu_128_encrypt      60135 ns        60132 ns        11183
-tinyjambu_128_decrypt      59994 ns        59993 ns        11085
-tinyjambu_192_encrypt      60280 ns        60278 ns        11107
-tinyjambu_192_decrypt      63265 ns        63260 ns        11010
-tinyjambu_256_encrypt      62988 ns        62980 ns        10757
-tinyjambu_256_decrypt      60500 ns        60496 ns        10829
+tinyjambu_128_encrypt      35807 ns        35806 ns        19346
+tinyjambu_128_decrypt      36383 ns        36381 ns        19390
+tinyjambu_192_encrypt      36396 ns        36395 ns        19260
+tinyjambu_192_decrypt      36662 ns        36657 ns        19093
+tinyjambu_256_encrypt      36532 ns        36529 ns        19344
+tinyjambu_256_decrypt      35906 ns        35902 ns        19545
 ```
 
 or when interested in computing 128 feedback bits each iteration
@@ -313,24 +313,24 @@ FBK=128 make bench_python
 ```
 
 ```bash
-2022-04-28T12:56:35+05:30
+2022-05-06T08:53:14+00:00
 Running bench_tinyjambu.py
-Run on (4 X 1895.73 MHz CPU s)
+Run on (4 X 2300 MHz CPU s)
 CPU Caches:
   L1 Data 32 KiB (x2)
   L1 Instruction 32 KiB (x2)
   L2 Unified 256 KiB (x2)
-  L3 Unified 3072 KiB (x1)
-Load Average: 0.54, 0.46, 0.41
+  L3 Unified 46080 KiB (x1)
+Load Average: 0.11, 0.22, 0.11
 ----------------------------------------------------------------
 Benchmark                      Time             CPU   Iterations
 ----------------------------------------------------------------
-tinyjambu_128_encrypt      70637 ns        70631 ns         9964
-tinyjambu_128_decrypt      67828 ns        67823 ns        10086
-tinyjambu_192_encrypt      68471 ns        68468 ns         9714
-tinyjambu_192_decrypt      68530 ns        68525 ns         9193
-tinyjambu_256_encrypt      69690 ns        69683 ns         9614
-tinyjambu_256_decrypt      76305 ns        76295 ns         9593
+tinyjambu_128_encrypt      36252 ns        36248 ns        19124
+tinyjambu_128_decrypt      36922 ns        36919 ns        19136
+tinyjambu_192_encrypt      36976 ns        36974 ns        19086
+tinyjambu_192_decrypt      37122 ns        37120 ns        18719
+tinyjambu_256_encrypt      36729 ns        36730 ns        19045
+tinyjambu_256_decrypt      36435 ns        36433 ns        19436
 ```
 
 ## Usage

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -7,70 +7,70 @@
 // Note, associated data size is kept constant for all benchmark cases !
 
 // TinyJambu-128 encrypt/ decrypt routines
-BENCHMARK(tinyjambu_128_encrypt_64B_32B);
-BENCHMARK(tinyjambu_128_decrypt_64B_32B);
+BENCHMARK(tinyjambu_128_encrypt)->Args({ 64, 32 });
+BENCHMARK(tinyjambu_128_decrypt)->Args({ 64, 32 });
 
-BENCHMARK(tinyjambu_128_encrypt_128B_32B);
-BENCHMARK(tinyjambu_128_decrypt_128B_32B);
+BENCHMARK(tinyjambu_128_encrypt)->Args({ 128, 32 });
+BENCHMARK(tinyjambu_128_decrypt)->Args({ 128, 32 });
 
-BENCHMARK(tinyjambu_128_encrypt_256B_32B);
-BENCHMARK(tinyjambu_128_decrypt_256B_32B);
+BENCHMARK(tinyjambu_128_encrypt)->Args({ 256, 32 });
+BENCHMARK(tinyjambu_128_decrypt)->Args({ 256, 32 });
 
-BENCHMARK(tinyjambu_128_encrypt_512B_32B);
-BENCHMARK(tinyjambu_128_decrypt_512B_32B);
+BENCHMARK(tinyjambu_128_encrypt)->Args({ 512, 32 });
+BENCHMARK(tinyjambu_128_decrypt)->Args({ 512, 32 });
 
-BENCHMARK(tinyjambu_128_encrypt_1024B_32B);
-BENCHMARK(tinyjambu_128_decrypt_1024B_32B);
+BENCHMARK(tinyjambu_128_encrypt)->Args({ 1024, 32 });
+BENCHMARK(tinyjambu_128_decrypt)->Args({ 1024, 32 });
 
-BENCHMARK(tinyjambu_128_encrypt_2048B_32B);
-BENCHMARK(tinyjambu_128_decrypt_2048B_32B);
+BENCHMARK(tinyjambu_128_encrypt)->Args({ 2048, 32 });
+BENCHMARK(tinyjambu_128_decrypt)->Args({ 2048, 32 });
 
-BENCHMARK(tinyjambu_128_encrypt_4096B_32B);
-BENCHMARK(tinyjambu_128_decrypt_4096B_32B);
+BENCHMARK(tinyjambu_128_encrypt)->Args({ 4096, 32 });
+BENCHMARK(tinyjambu_128_decrypt)->Args({ 4096, 32 });
 
 // TinyJambu-192 encrypt/ decrypt routines
-BENCHMARK(tinyjambu_192_encrypt_64B_32B);
-BENCHMARK(tinyjambu_192_decrypt_64B_32B);
+BENCHMARK(tinyjambu_192_encrypt)->Args({ 64, 32 });
+BENCHMARK(tinyjambu_192_decrypt)->Args({ 64, 32 });
 
-BENCHMARK(tinyjambu_192_encrypt_128B_32B);
-BENCHMARK(tinyjambu_192_decrypt_128B_32B);
+BENCHMARK(tinyjambu_192_encrypt)->Args({ 128, 32 });
+BENCHMARK(tinyjambu_192_decrypt)->Args({ 128, 32 });
 
-BENCHMARK(tinyjambu_192_encrypt_256B_32B);
-BENCHMARK(tinyjambu_192_decrypt_256B_32B);
+BENCHMARK(tinyjambu_192_encrypt)->Args({ 256, 32 });
+BENCHMARK(tinyjambu_192_decrypt)->Args({ 256, 32 });
 
-BENCHMARK(tinyjambu_192_encrypt_512B_32B);
-BENCHMARK(tinyjambu_192_decrypt_512B_32B);
+BENCHMARK(tinyjambu_192_encrypt)->Args({ 512, 32 });
+BENCHMARK(tinyjambu_192_decrypt)->Args({ 512, 32 });
 
-BENCHMARK(tinyjambu_192_encrypt_1024B_32B);
-BENCHMARK(tinyjambu_192_decrypt_1024B_32B);
+BENCHMARK(tinyjambu_192_encrypt)->Args({ 1024, 32 });
+BENCHMARK(tinyjambu_192_decrypt)->Args({ 1024, 32 });
 
-BENCHMARK(tinyjambu_192_encrypt_2048B_32B);
-BENCHMARK(tinyjambu_192_decrypt_2048B_32B);
+BENCHMARK(tinyjambu_192_encrypt)->Args({ 2048, 32 });
+BENCHMARK(tinyjambu_192_decrypt)->Args({ 2048, 32 });
 
-BENCHMARK(tinyjambu_192_encrypt_4096B_32B);
-BENCHMARK(tinyjambu_192_decrypt_4096B_32B);
+BENCHMARK(tinyjambu_192_encrypt)->Args({ 4096, 32 });
+BENCHMARK(tinyjambu_192_decrypt)->Args({ 4096, 32 });
 
 // TinyJambu-256 encrypt/ decrypt routines
-BENCHMARK(tinyjambu_256_encrypt_64B_32B);
-BENCHMARK(tinyjambu_256_decrypt_64B_32B);
+BENCHMARK(tinyjambu_256_encrypt)->Args({ 64, 32 });
+BENCHMARK(tinyjambu_256_decrypt)->Args({ 64, 32 });
 
-BENCHMARK(tinyjambu_256_encrypt_128B_32B);
-BENCHMARK(tinyjambu_256_decrypt_128B_32B);
+BENCHMARK(tinyjambu_256_encrypt)->Args({ 128, 32 });
+BENCHMARK(tinyjambu_256_decrypt)->Args({ 128, 32 });
 
-BENCHMARK(tinyjambu_256_encrypt_256B_32B);
-BENCHMARK(tinyjambu_256_decrypt_256B_32B);
+BENCHMARK(tinyjambu_256_encrypt)->Args({ 256, 32 });
+BENCHMARK(tinyjambu_256_decrypt)->Args({ 256, 32 });
 
-BENCHMARK(tinyjambu_256_encrypt_512B_32B);
-BENCHMARK(tinyjambu_256_decrypt_512B_32B);
+BENCHMARK(tinyjambu_256_encrypt)->Args({ 512, 32 });
+BENCHMARK(tinyjambu_256_decrypt)->Args({ 512, 32 });
 
-BENCHMARK(tinyjambu_256_encrypt_1024B_32B);
-BENCHMARK(tinyjambu_256_decrypt_1024B_32B);
+BENCHMARK(tinyjambu_256_encrypt)->Args({ 1024, 32 });
+BENCHMARK(tinyjambu_256_decrypt)->Args({ 1024, 32 });
 
-BENCHMARK(tinyjambu_256_encrypt_2048B_32B);
-BENCHMARK(tinyjambu_256_decrypt_2048B_32B);
+BENCHMARK(tinyjambu_256_encrypt)->Args({ 2048, 32 });
+BENCHMARK(tinyjambu_256_decrypt)->Args({ 2048, 32 });
 
-BENCHMARK(tinyjambu_256_encrypt_4096B_32B);
-BENCHMARK(tinyjambu_256_decrypt_4096B_32B);
+BENCHMARK(tinyjambu_256_encrypt)->Args({ 4096, 32 });
+BENCHMARK(tinyjambu_256_decrypt)->Args({ 4096, 32 });
 
 // main function to make it executable
 BENCHMARK_MAIN();

--- a/bench/main.cpp
+++ b/bench/main.cpp
@@ -6,60 +6,70 @@
 //
 // Note, associated data size is kept constant for all benchmark cases !
 
-// TinyJambu-128 encrypt routine
+// TinyJambu-128 encrypt/ decrypt routines
 BENCHMARK(tinyjambu_128_encrypt_64B_32B);
-BENCHMARK(tinyjambu_128_encrypt_128B_32B);
-BENCHMARK(tinyjambu_128_encrypt_256B_32B);
-BENCHMARK(tinyjambu_128_encrypt_512B_32B);
-BENCHMARK(tinyjambu_128_encrypt_1024B_32B);
-BENCHMARK(tinyjambu_128_encrypt_2048B_32B);
-BENCHMARK(tinyjambu_128_encrypt_4096B_32B);
-
-// TinyJambu-192 encrypt routine
-BENCHMARK(tinyjambu_192_encrypt_64B_32B);
-BENCHMARK(tinyjambu_192_encrypt_128B_32B);
-BENCHMARK(tinyjambu_192_encrypt_256B_32B);
-BENCHMARK(tinyjambu_192_encrypt_512B_32B);
-BENCHMARK(tinyjambu_192_encrypt_1024B_32B);
-BENCHMARK(tinyjambu_192_encrypt_2048B_32B);
-BENCHMARK(tinyjambu_192_encrypt_4096B_32B);
-
-// TinyJambu-256 encrypt routine
-BENCHMARK(tinyjambu_256_encrypt_64B_32B);
-BENCHMARK(tinyjambu_256_encrypt_128B_32B);
-BENCHMARK(tinyjambu_256_encrypt_256B_32B);
-BENCHMARK(tinyjambu_256_encrypt_512B_32B);
-BENCHMARK(tinyjambu_256_encrypt_1024B_32B);
-BENCHMARK(tinyjambu_256_encrypt_2048B_32B);
-BENCHMARK(tinyjambu_256_encrypt_4096B_32B);
-
-// ---
-
-// TinyJambu-128 decrypt routine
 BENCHMARK(tinyjambu_128_decrypt_64B_32B);
+
+BENCHMARK(tinyjambu_128_encrypt_128B_32B);
 BENCHMARK(tinyjambu_128_decrypt_128B_32B);
+
+BENCHMARK(tinyjambu_128_encrypt_256B_32B);
 BENCHMARK(tinyjambu_128_decrypt_256B_32B);
+
+BENCHMARK(tinyjambu_128_encrypt_512B_32B);
 BENCHMARK(tinyjambu_128_decrypt_512B_32B);
+
+BENCHMARK(tinyjambu_128_encrypt_1024B_32B);
 BENCHMARK(tinyjambu_128_decrypt_1024B_32B);
+
+BENCHMARK(tinyjambu_128_encrypt_2048B_32B);
 BENCHMARK(tinyjambu_128_decrypt_2048B_32B);
+
+BENCHMARK(tinyjambu_128_encrypt_4096B_32B);
 BENCHMARK(tinyjambu_128_decrypt_4096B_32B);
 
-// TinyJambu-192 decrypt routine
+// TinyJambu-192 encrypt/ decrypt routines
+BENCHMARK(tinyjambu_192_encrypt_64B_32B);
 BENCHMARK(tinyjambu_192_decrypt_64B_32B);
+
+BENCHMARK(tinyjambu_192_encrypt_128B_32B);
 BENCHMARK(tinyjambu_192_decrypt_128B_32B);
+
+BENCHMARK(tinyjambu_192_encrypt_256B_32B);
 BENCHMARK(tinyjambu_192_decrypt_256B_32B);
+
+BENCHMARK(tinyjambu_192_encrypt_512B_32B);
 BENCHMARK(tinyjambu_192_decrypt_512B_32B);
+
+BENCHMARK(tinyjambu_192_encrypt_1024B_32B);
 BENCHMARK(tinyjambu_192_decrypt_1024B_32B);
+
+BENCHMARK(tinyjambu_192_encrypt_2048B_32B);
 BENCHMARK(tinyjambu_192_decrypt_2048B_32B);
+
+BENCHMARK(tinyjambu_192_encrypt_4096B_32B);
 BENCHMARK(tinyjambu_192_decrypt_4096B_32B);
 
-// TinyJambu-256 decrypt routine
+// TinyJambu-256 encrypt/ decrypt routines
+BENCHMARK(tinyjambu_256_encrypt_64B_32B);
 BENCHMARK(tinyjambu_256_decrypt_64B_32B);
+
+BENCHMARK(tinyjambu_256_encrypt_128B_32B);
 BENCHMARK(tinyjambu_256_decrypt_128B_32B);
+
+BENCHMARK(tinyjambu_256_encrypt_256B_32B);
 BENCHMARK(tinyjambu_256_decrypt_256B_32B);
+
+BENCHMARK(tinyjambu_256_encrypt_512B_32B);
 BENCHMARK(tinyjambu_256_decrypt_512B_32B);
+
+BENCHMARK(tinyjambu_256_encrypt_1024B_32B);
 BENCHMARK(tinyjambu_256_decrypt_1024B_32B);
+
+BENCHMARK(tinyjambu_256_encrypt_2048B_32B);
 BENCHMARK(tinyjambu_256_decrypt_2048B_32B);
+
+BENCHMARK(tinyjambu_256_encrypt_4096B_32B);
 BENCHMARK(tinyjambu_256_decrypt_4096B_32B);
 
 // main function to make it executable

--- a/include/bench_tinyjambu_128.hpp
+++ b/include/bench_tinyjambu_128.hpp
@@ -29,17 +29,17 @@ tinyjambu_128_encrypt(benchmark::State& state,
   memset(enc, 0, ct_len);
   memset(tag, 0, 8);
 
-  size_t itr = 0;
   for (auto _ : state) {
     tinyjambu_128::encrypt(key, nonce, data, dt_len, text, enc, ct_len, tag);
 
     benchmark::DoNotOptimize(enc);
     benchmark::DoNotOptimize(tag);
-    benchmark::DoNotOptimize(itr++);
   }
 
-  state.SetBytesProcessed(static_cast<int64_t>((dt_len + ct_len) * itr));
-  state.SetItemsProcessed(static_cast<int64_t>(itr));
+  const size_t per_itr_data = dt_len + ct_len;
+  const size_t total_data = per_itr_data * state.iterations();
+
+  state.SetBytesProcessed(static_cast<int64_t>(total_data));
 
   // deallocate all resources
   free(text);
@@ -80,18 +80,18 @@ tinyjambu_128_decrypt(benchmark::State& state,
 
   tinyjambu_128::encrypt(key, nonce, data, dt_len, text, enc, ct_len, tag);
 
-  size_t itr = 0;
   for (auto _ : state) {
     using namespace tinyjambu_128;
     using namespace benchmark;
 
     DoNotOptimize(decrypt(key, nonce, tag, data, dt_len, enc, dec, ct_len));
     DoNotOptimize(dec);
-    DoNotOptimize(itr++);
   }
 
-  state.SetBytesProcessed(static_cast<int64_t>((dt_len + ct_len) * itr));
-  state.SetItemsProcessed(static_cast<int64_t>(itr));
+  const size_t per_itr_data = dt_len + ct_len;
+  const size_t total_data = per_itr_data * state.iterations();
+
+  state.SetBytesProcessed(static_cast<int64_t>(total_data));
 
   // deallocate all resources
   free(text);

--- a/include/bench_tinyjambu_128.hpp
+++ b/include/bench_tinyjambu_128.hpp
@@ -5,10 +5,11 @@
 
 // Benchmark TinyJambu-128 authenticated encryption routine
 static void
-tinyjambu_128_encrypt(benchmark::State& state,
-                      const size_t ct_len,
-                      const size_t dt_len)
+tinyjambu_128_encrypt(benchmark::State& state)
 {
+  const size_t ct_len = state.range(0);
+  const size_t dt_len = state.range(1);
+
   // acquire memory resources
   uint8_t* text = static_cast<uint8_t*>(malloc(ct_len));
   uint8_t* enc = static_cast<uint8_t*>(malloc(ct_len));
@@ -52,10 +53,11 @@ tinyjambu_128_encrypt(benchmark::State& state,
 
 // Benchmark TinyJambu-128 verified decryption routine
 static void
-tinyjambu_128_decrypt(benchmark::State& state,
-                      const size_t ct_len,
-                      const size_t dt_len)
+tinyjambu_128_decrypt(benchmark::State& state)
 {
+  const size_t ct_len = state.range(0);
+  const size_t dt_len = state.range(1);
+
   // acquire memory resources
   uint8_t* text = static_cast<uint8_t*>(malloc(ct_len));
   uint8_t* enc = static_cast<uint8_t*>(malloc(ct_len));
@@ -101,116 +103,4 @@ tinyjambu_128_decrypt(benchmark::State& state,
   free(key);
   free(nonce);
   free(tag);
-}
-
-// Benchmark TinyJambu-128 encrypt routine with 64 -bytes plain text & 32 -bytes
-// associated data
-static void
-tinyjambu_128_encrypt_64B_32B(benchmark::State& state)
-{
-  tinyjambu_128_encrypt(state, 64ul, 32ul);
-}
-
-// Benchmark TinyJambu-128 encrypt routine with 128 -bytes plain text & 32
-// -bytes associated data
-static void
-tinyjambu_128_encrypt_128B_32B(benchmark::State& state)
-{
-  tinyjambu_128_encrypt(state, 128ul, 32ul);
-}
-
-// Benchmark TinyJambu-128 encrypt routine with 256 -bytes plain text & 32
-// -bytes associated data
-static void
-tinyjambu_128_encrypt_256B_32B(benchmark::State& state)
-{
-  tinyjambu_128_encrypt(state, 256ul, 32ul);
-}
-
-// Benchmark TinyJambu-128 encrypt routine with 512 -bytes plain text & 32
-// -bytes associated data
-static void
-tinyjambu_128_encrypt_512B_32B(benchmark::State& state)
-{
-  tinyjambu_128_encrypt(state, 512ul, 32ul);
-}
-
-// Benchmark TinyJambu-128 encrypt routine with 1024 -bytes plain text & 32
-// -bytes associated data
-static void
-tinyjambu_128_encrypt_1024B_32B(benchmark::State& state)
-{
-  tinyjambu_128_encrypt(state, 1024ul, 32ul);
-}
-
-// Benchmark TinyJambu-128 encrypt routine with 2048 -bytes plain text & 32
-// -bytes associated data
-static void
-tinyjambu_128_encrypt_2048B_32B(benchmark::State& state)
-{
-  tinyjambu_128_encrypt(state, 2048ul, 32ul);
-}
-
-// Benchmark TinyJambu-128 encrypt routine with 4096 -bytes plain text & 32
-// -bytes associated data
-static void
-tinyjambu_128_encrypt_4096B_32B(benchmark::State& state)
-{
-  tinyjambu_128_encrypt(state, 4096ul, 32ul);
-}
-
-// Benchmark TinyJambu-128 decrypt routine with 64 -bytes cipher text & 32
-// -bytes associated data
-static void
-tinyjambu_128_decrypt_64B_32B(benchmark::State& state)
-{
-  tinyjambu_128_decrypt(state, 64ul, 32ul);
-}
-
-// Benchmark TinyJambu-128 decrypt routine with 128 -bytes cipher text & 32
-// -bytes associated data
-static void
-tinyjambu_128_decrypt_128B_32B(benchmark::State& state)
-{
-  tinyjambu_128_decrypt(state, 128ul, 32ul);
-}
-
-// Benchmark TinyJambu-128 decrypt routine with 256 -bytes cipher text & 32
-// -bytes associated data
-static void
-tinyjambu_128_decrypt_256B_32B(benchmark::State& state)
-{
-  tinyjambu_128_decrypt(state, 256ul, 32ul);
-}
-
-// Benchmark TinyJambu-128 decrypt routine with 512 -bytes cipher text & 32
-// -bytes associated data
-static void
-tinyjambu_128_decrypt_512B_32B(benchmark::State& state)
-{
-  tinyjambu_128_decrypt(state, 512ul, 32ul);
-}
-
-// Benchmark TinyJambu-128 decrypt routine with 1024 -bytes cipher text & 32
-// -bytes associated data
-static void
-tinyjambu_128_decrypt_1024B_32B(benchmark::State& state)
-{
-  tinyjambu_128_decrypt(state, 1024ul, 32ul);
-}
-
-// Benchmark TinyJambu-128 decrypt routine with 2048 -bytes cipher text & 32
-// -bytes associated data
-static void
-tinyjambu_128_decrypt_2048B_32B(benchmark::State& state)
-{
-  tinyjambu_128_decrypt(state, 2048ul, 32ul);
-}
-
-// Benchmark TinyJambu-128 decrypt routine with 4096 -bytes cipher text & 32
-// -bytes associated data
-static void
-tinyjambu_128_decrypt_4096B_32B(benchmark::State& state)
-{
-  tinyjambu_128_decrypt(state, 4096ul, 32ul);
 }

--- a/include/bench_tinyjambu_192.hpp
+++ b/include/bench_tinyjambu_192.hpp
@@ -29,17 +29,17 @@ tinyjambu_192_encrypt(benchmark::State& state,
   memset(enc, 0, ct_len);
   memset(tag, 0, 8);
 
-  size_t itr = 0;
   for (auto _ : state) {
     tinyjambu_192::encrypt(key, nonce, data, dt_len, text, enc, ct_len, tag);
 
     benchmark::DoNotOptimize(enc);
     benchmark::DoNotOptimize(tag);
-    benchmark::DoNotOptimize(itr++);
   }
 
-  state.SetBytesProcessed(static_cast<int64_t>((dt_len + ct_len) * itr));
-  state.SetItemsProcessed(static_cast<int64_t>(itr));
+  const size_t per_itr_data = dt_len + ct_len;
+  const size_t total_data = per_itr_data * state.iterations();
+
+  state.SetBytesProcessed(static_cast<int64_t>(total_data));
 
   // deallocate all resources
   free(text);
@@ -80,18 +80,18 @@ tinyjambu_192_decrypt(benchmark::State& state,
 
   tinyjambu_192::encrypt(key, nonce, data, dt_len, text, enc, ct_len, tag);
 
-  size_t itr = 0;
   for (auto _ : state) {
     using namespace tinyjambu_192;
     using namespace benchmark;
 
     DoNotOptimize(decrypt(key, nonce, tag, data, dt_len, enc, dec, ct_len));
     DoNotOptimize(dec);
-    DoNotOptimize(itr++);
   }
 
-  state.SetBytesProcessed(static_cast<int64_t>((dt_len + ct_len) * itr));
-  state.SetItemsProcessed(static_cast<int64_t>(itr));
+  const size_t per_itr_data = dt_len + ct_len;
+  const size_t total_data = per_itr_data * state.iterations();
+
+  state.SetBytesProcessed(static_cast<int64_t>(total_data));
 
   // deallocate all resources
   free(text);

--- a/include/bench_tinyjambu_192.hpp
+++ b/include/bench_tinyjambu_192.hpp
@@ -5,10 +5,11 @@
 
 // Benchmark TinyJambu-192 authenticated encryption routine
 static void
-tinyjambu_192_encrypt(benchmark::State& state,
-                      const size_t ct_len,
-                      const size_t dt_len)
+tinyjambu_192_encrypt(benchmark::State& state)
 {
+  const size_t ct_len = state.range(0);
+  const size_t dt_len = state.range(1);
+
   // acquire memory resources
   uint8_t* text = static_cast<uint8_t*>(malloc(ct_len));
   uint8_t* enc = static_cast<uint8_t*>(malloc(ct_len));
@@ -52,10 +53,11 @@ tinyjambu_192_encrypt(benchmark::State& state,
 
 // Benchmark TinyJambu-192 verified decryption routine
 static void
-tinyjambu_192_decrypt(benchmark::State& state,
-                      const size_t ct_len,
-                      const size_t dt_len)
+tinyjambu_192_decrypt(benchmark::State& state)
 {
+  const size_t ct_len = state.range(0);
+  const size_t dt_len = state.range(1);
+
   // acquire memory resources
   uint8_t* text = static_cast<uint8_t*>(malloc(ct_len));
   uint8_t* enc = static_cast<uint8_t*>(malloc(ct_len));
@@ -101,116 +103,4 @@ tinyjambu_192_decrypt(benchmark::State& state,
   free(key);
   free(nonce);
   free(tag);
-}
-
-// Benchmark TinyJambu-192 encrypt routine with 64 -bytes plain text & 32 -bytes
-// associated data
-static void
-tinyjambu_192_encrypt_64B_32B(benchmark::State& state)
-{
-  tinyjambu_192_encrypt(state, 64ul, 32ul);
-}
-
-// Benchmark TinyJambu-192 encrypt routine with 128 -bytes plain text & 32
-// -bytes associated data
-static void
-tinyjambu_192_encrypt_128B_32B(benchmark::State& state)
-{
-  tinyjambu_192_encrypt(state, 128ul, 32ul);
-}
-
-// Benchmark TinyJambu-192 encrypt routine with 256 -bytes plain text & 32
-// -bytes associated data
-static void
-tinyjambu_192_encrypt_256B_32B(benchmark::State& state)
-{
-  tinyjambu_192_encrypt(state, 256ul, 32ul);
-}
-
-// Benchmark TinyJambu-192 encrypt routine with 512 -bytes plain text & 32
-// -bytes associated data
-static void
-tinyjambu_192_encrypt_512B_32B(benchmark::State& state)
-{
-  tinyjambu_192_encrypt(state, 512ul, 32ul);
-}
-
-// Benchmark TinyJambu-192 encrypt routine with 1024 -bytes plain text & 32
-// -bytes associated data
-static void
-tinyjambu_192_encrypt_1024B_32B(benchmark::State& state)
-{
-  tinyjambu_192_encrypt(state, 1024ul, 32ul);
-}
-
-// Benchmark TinyJambu-192 encrypt routine with 2048 -bytes plain text & 32
-// -bytes associated data
-static void
-tinyjambu_192_encrypt_2048B_32B(benchmark::State& state)
-{
-  tinyjambu_192_encrypt(state, 2048ul, 32ul);
-}
-
-// Benchmark TinyJambu-192 encrypt routine with 4096 -bytes plain text & 32
-// -bytes associated data
-static void
-tinyjambu_192_encrypt_4096B_32B(benchmark::State& state)
-{
-  tinyjambu_192_encrypt(state, 4096ul, 32ul);
-}
-
-// Benchmark TinyJambu-192 decrypt routine with 64 -bytes cipher text & 32
-// -bytes associated data
-static void
-tinyjambu_192_decrypt_64B_32B(benchmark::State& state)
-{
-  tinyjambu_192_decrypt(state, 64ul, 32ul);
-}
-
-// Benchmark TinyJambu-192 decrypt routine with 128 -bytes cipher text & 32
-// -bytes associated data
-static void
-tinyjambu_192_decrypt_128B_32B(benchmark::State& state)
-{
-  tinyjambu_192_decrypt(state, 128ul, 32ul);
-}
-
-// Benchmark TinyJambu-192 decrypt routine with 256 -bytes cipher text & 32
-// -bytes associated data
-static void
-tinyjambu_192_decrypt_256B_32B(benchmark::State& state)
-{
-  tinyjambu_192_decrypt(state, 256ul, 32ul);
-}
-
-// Benchmark TinyJambu-192 decrypt routine with 512 -bytes cipher text & 32
-// -bytes associated data
-static void
-tinyjambu_192_decrypt_512B_32B(benchmark::State& state)
-{
-  tinyjambu_192_decrypt(state, 512ul, 32ul);
-}
-
-// Benchmark TinyJambu-192 decrypt routine with 1024 -bytes cipher text & 32
-// -bytes associated data
-static void
-tinyjambu_192_decrypt_1024B_32B(benchmark::State& state)
-{
-  tinyjambu_192_decrypt(state, 1024ul, 32ul);
-}
-
-// Benchmark TinyJambu-192 decrypt routine with 2048 -bytes cipher text & 32
-// -bytes associated data
-static void
-tinyjambu_192_decrypt_2048B_32B(benchmark::State& state)
-{
-  tinyjambu_192_decrypt(state, 2048ul, 32ul);
-}
-
-// Benchmark TinyJambu-192 decrypt routine with 4096 -bytes cipher text & 32
-// -bytes associated data
-static void
-tinyjambu_192_decrypt_4096B_32B(benchmark::State& state)
-{
-  tinyjambu_192_decrypt(state, 4096ul, 32ul);
 }

--- a/include/bench_tinyjambu_256.hpp
+++ b/include/bench_tinyjambu_256.hpp
@@ -29,17 +29,17 @@ tinyjambu_256_encrypt(benchmark::State& state,
   memset(enc, 0, ct_len);
   memset(tag, 0, 8);
 
-  size_t itr = 0;
   for (auto _ : state) {
     tinyjambu_256::encrypt(key, nonce, data, dt_len, text, enc, ct_len, tag);
 
     benchmark::DoNotOptimize(enc);
     benchmark::DoNotOptimize(tag);
-    benchmark::DoNotOptimize(itr++);
   }
 
-  state.SetBytesProcessed(static_cast<int64_t>((dt_len + ct_len) * itr));
-  state.SetItemsProcessed(static_cast<int64_t>(itr));
+  const size_t per_itr_data = dt_len + ct_len;
+  const size_t total_data = per_itr_data * state.iterations();
+
+  state.SetBytesProcessed(static_cast<int64_t>(total_data));
 
   // deallocate all resources
   free(text);
@@ -80,18 +80,18 @@ tinyjambu_256_decrypt(benchmark::State& state,
 
   tinyjambu_256::encrypt(key, nonce, data, dt_len, text, enc, ct_len, tag);
 
-  size_t itr = 0;
   for (auto _ : state) {
     using namespace tinyjambu_256;
     using namespace benchmark;
 
     DoNotOptimize(decrypt(key, nonce, tag, data, dt_len, enc, dec, ct_len));
     DoNotOptimize(dec);
-    DoNotOptimize(itr++);
   }
 
-  state.SetBytesProcessed(static_cast<int64_t>((dt_len + ct_len) * itr));
-  state.SetItemsProcessed(static_cast<int64_t>(itr));
+  const size_t per_itr_data = dt_len + ct_len;
+  const size_t total_data = per_itr_data * state.iterations();
+
+  state.SetBytesProcessed(static_cast<int64_t>(total_data));
 
   // deallocate all resources
   free(text);

--- a/include/bench_tinyjambu_256.hpp
+++ b/include/bench_tinyjambu_256.hpp
@@ -5,10 +5,11 @@
 
 // Benchmark TinyJambu-256 authenticated encryption routine
 static void
-tinyjambu_256_encrypt(benchmark::State& state,
-                      const size_t ct_len,
-                      const size_t dt_len)
+tinyjambu_256_encrypt(benchmark::State& state)
 {
+  const size_t ct_len = state.range(0);
+  const size_t dt_len = state.range(1);
+
   // acquire memory resources
   uint8_t* text = static_cast<uint8_t*>(malloc(ct_len));
   uint8_t* enc = static_cast<uint8_t*>(malloc(ct_len));
@@ -52,10 +53,11 @@ tinyjambu_256_encrypt(benchmark::State& state,
 
 // Benchmark TinyJambu-256 verified decryption routine
 static void
-tinyjambu_256_decrypt(benchmark::State& state,
-                      const size_t ct_len,
-                      const size_t dt_len)
+tinyjambu_256_decrypt(benchmark::State& state)
 {
+  const size_t ct_len = state.range(0);
+  const size_t dt_len = state.range(1);
+
   // acquire memory resources
   uint8_t* text = static_cast<uint8_t*>(malloc(ct_len));
   uint8_t* enc = static_cast<uint8_t*>(malloc(ct_len));
@@ -101,116 +103,4 @@ tinyjambu_256_decrypt(benchmark::State& state,
   free(key);
   free(nonce);
   free(tag);
-}
-
-// Benchmark TinyJambu-256 encrypt routine with 64 -bytes plain text & 32 -bytes
-// associated data
-static void
-tinyjambu_256_encrypt_64B_32B(benchmark::State& state)
-{
-  tinyjambu_256_encrypt(state, 64ul, 32ul);
-}
-
-// Benchmark TinyJambu-256 encrypt routine with 128 -bytes plain text & 32
-// -bytes associated data
-static void
-tinyjambu_256_encrypt_128B_32B(benchmark::State& state)
-{
-  tinyjambu_256_encrypt(state, 128ul, 32ul);
-}
-
-// Benchmark TinyJambu-256 encrypt routine with 256 -bytes plain text & 32
-// -bytes associated data
-static void
-tinyjambu_256_encrypt_256B_32B(benchmark::State& state)
-{
-  tinyjambu_256_encrypt(state, 256ul, 32ul);
-}
-
-// Benchmark TinyJambu-256 encrypt routine with 512 -bytes plain text & 32
-// -bytes associated data
-static void
-tinyjambu_256_encrypt_512B_32B(benchmark::State& state)
-{
-  tinyjambu_256_encrypt(state, 512ul, 32ul);
-}
-
-// Benchmark TinyJambu-256 encrypt routine with 1024 -bytes plain text & 32
-// -bytes associated data
-static void
-tinyjambu_256_encrypt_1024B_32B(benchmark::State& state)
-{
-  tinyjambu_256_encrypt(state, 1024ul, 32ul);
-}
-
-// Benchmark TinyJambu-256 encrypt routine with 2048 -bytes plain text & 32
-// -bytes associated data
-static void
-tinyjambu_256_encrypt_2048B_32B(benchmark::State& state)
-{
-  tinyjambu_256_encrypt(state, 2048ul, 32ul);
-}
-
-// Benchmark TinyJambu-256 encrypt routine with 4096 -bytes plain text & 32
-// -bytes associated data
-static void
-tinyjambu_256_encrypt_4096B_32B(benchmark::State& state)
-{
-  tinyjambu_256_encrypt(state, 4096ul, 32ul);
-}
-
-// Benchmark TinyJambu-256 decrypt routine with 64 -bytes cipher text & 32
-// -bytes associated data
-static void
-tinyjambu_256_decrypt_64B_32B(benchmark::State& state)
-{
-  tinyjambu_256_decrypt(state, 64ul, 32ul);
-}
-
-// Benchmark TinyJambu-256 decrypt routine with 128 -bytes cipher text & 32
-// -bytes associated data
-static void
-tinyjambu_256_decrypt_128B_32B(benchmark::State& state)
-{
-  tinyjambu_256_decrypt(state, 128ul, 32ul);
-}
-
-// Benchmark TinyJambu-256 decrypt routine with 256 -bytes cipher text & 32
-// -bytes associated data
-static void
-tinyjambu_256_decrypt_256B_32B(benchmark::State& state)
-{
-  tinyjambu_256_decrypt(state, 256ul, 32ul);
-}
-
-// Benchmark TinyJambu-256 decrypt routine with 512 -bytes cipher text & 32
-// -bytes associated data
-static void
-tinyjambu_256_decrypt_512B_32B(benchmark::State& state)
-{
-  tinyjambu_256_decrypt(state, 512ul, 32ul);
-}
-
-// Benchmark TinyJambu-256 decrypt routine with 1024 -bytes cipher text & 32
-// -bytes associated data
-static void
-tinyjambu_256_decrypt_1024B_32B(benchmark::State& state)
-{
-  tinyjambu_256_decrypt(state, 1024ul, 32ul);
-}
-
-// Benchmark TinyJambu-256 decrypt routine with 2048 -bytes cipher text & 32
-// -bytes associated data
-static void
-tinyjambu_256_decrypt_2048B_32B(benchmark::State& state)
-{
-  tinyjambu_256_decrypt(state, 2048ul, 32ul);
-}
-
-// Benchmark TinyJambu-256 decrypt routine with 4096 -bytes cipher text & 32
-// -bytes associated data
-static void
-tinyjambu_256_decrypt_4096B_32B(benchmark::State& state)
-{
-  tinyjambu_256_decrypt(state, 4096ul, 32ul);
 }

--- a/include/permute.hpp
+++ b/include/permute.hpp
@@ -54,14 +54,14 @@ state_update(uint32_t* const __restrict state,    // 128 -bit permutation state
 #if defined FBK_32
   const size_t itr_cnt = rounds >> 5;
 
-  for (size_t i = 0, j = 0; i < itr_cnt; i++, j++) {
+  for (size_t i = 0; i < itr_cnt; i++) {
     const uint32_t s47 = (state[2] << 17) | (state[1] >> 15);
     const uint32_t s70 = (state[3] << 26) | (state[2] >> 6);
     const uint32_t s85 = (state[3] << 11) | (state[2] >> 21);
     const uint32_t s91 = (state[3] << 5) | (state[2] >> 27);
 
     // computed 32 feedback bits
-    const uint32_t fbk = state[0] ^ s47 ^ (~(s70 & s85)) ^ s91 ^ key[j & 3ul];
+    const uint32_t fbk = state[0] ^ s47 ^ (~(s70 & s85)) ^ s91 ^ key[i & 3ul];
 
     state[0] = state[1];
     state[1] = state[2];
@@ -224,14 +224,14 @@ state_update(uint32_t* const __restrict state,    // 128 -bit permutation state
 #if defined FBK_32
   const size_t itr_cnt = rounds >> 5;
 
-  for (size_t i = 0, j = 0; i < itr_cnt; i++, j++) {
+  for (size_t i = 0; i < itr_cnt; i++) {
     const uint32_t s47 = (state[2] << 17) | (state[1] >> 15);
     const uint32_t s70 = (state[3] << 26) | (state[2] >> 6);
     const uint32_t s85 = (state[3] << 11) | (state[2] >> 21);
     const uint32_t s91 = (state[3] << 5) | (state[2] >> 27);
 
     // computed 32 feedback bits
-    const uint32_t fbk = state[0] ^ s47 ^ (~(s70 & s85)) ^ s91 ^ key[j & 7ul];
+    const uint32_t fbk = state[0] ^ s47 ^ (~(s70 & s85)) ^ s91 ^ key[i & 7ul];
 
     state[0] = state[1];
     state[1] = state[2];
@@ -248,7 +248,7 @@ state_update(uint32_t* const __restrict state,    // 128 -bit permutation state
       const uint32_t s85 = (state[3] << 11) | (state[2] >> 21);
       const uint32_t s91 = (state[3] << 5) | (state[2] >> 27);
 
-      state[0] = state[0] ^ s47 ^ (~(s70 & s85)) ^ s91 ^ key[(j + 0ul) & 7ul];
+      state[0] = state[0] ^ s47 ^ (~(s70 & s85)) ^ s91 ^ key[(j ^ 0ul) & 7ul];
     }
     {
       const uint32_t s47 = (state[3] << 17) | (state[2] >> 15);
@@ -256,7 +256,7 @@ state_update(uint32_t* const __restrict state,    // 128 -bit permutation state
       const uint32_t s85 = (state[0] << 11) | (state[3] >> 21);
       const uint32_t s91 = (state[0] << 5) | (state[3] >> 27);
 
-      state[1] = state[1] ^ s47 ^ (~(s70 & s85)) ^ s91 ^ key[(j + 1ul) & 7ul];
+      state[1] = state[1] ^ s47 ^ (~(s70 & s85)) ^ s91 ^ key[(j ^ 1ul) & 7ul];
     }
     {
       const uint32_t s47 = (state[0] << 17) | (state[3] >> 15);
@@ -264,7 +264,7 @@ state_update(uint32_t* const __restrict state,    // 128 -bit permutation state
       const uint32_t s85 = (state[1] << 11) | (state[0] >> 21);
       const uint32_t s91 = (state[1] << 5) | (state[0] >> 27);
 
-      state[2] = state[2] ^ s47 ^ (~(s70 & s85)) ^ s91 ^ key[(j + 2ul) & 7ul];
+      state[2] = state[2] ^ s47 ^ (~(s70 & s85)) ^ s91 ^ key[(j ^ 2ul) & 7ul];
     }
     {
       const uint32_t s47 = (state[1] << 17) | (state[0] >> 15);
@@ -272,7 +272,7 @@ state_update(uint32_t* const __restrict state,    // 128 -bit permutation state
       const uint32_t s85 = (state[2] << 11) | (state[1] >> 21);
       const uint32_t s91 = (state[2] << 5) | (state[1] >> 27);
 
-      state[3] = state[3] ^ s47 ^ (~(s70 & s85)) ^ s91 ^ key[(j + 3ul) & 7ul];
+      state[3] = state[3] ^ s47 ^ (~(s70 & s85)) ^ s91 ^ key[(j ^ 3ul) & 7ul];
     }
   }
 #endif

--- a/include/permute.hpp
+++ b/include/permute.hpp
@@ -134,23 +134,21 @@ state_update(uint32_t* const __restrict state,    // 128 -bit permutation state
 #if defined FBK_32
   const size_t itr_cnt = rounds >> 5;
 
-  for (size_t i = 0, j = 0; i < itr_cnt; i++) {
+  for (size_t i = 0; i < itr_cnt; i++) {
+    const size_t j = i % 6ul;
+
     const uint32_t s47 = (state[2] << 17) | (state[1] >> 15);
     const uint32_t s70 = (state[3] << 26) | (state[2] >> 6);
     const uint32_t s85 = (state[3] << 11) | (state[2] >> 21);
     const uint32_t s91 = (state[3] << 5) | (state[2] >> 27);
 
     // computed 32 feedback bits
-    const uint32_t fbk = state[0] ^ s47 ^ (~(s70 & s85)) ^ s91 ^ key[j++];
+    const uint32_t fbk = state[0] ^ s47 ^ (~(s70 & s85)) ^ s91 ^ key[j];
 
     state[0] = state[1];
     state[1] = state[2];
     state[2] = state[3];
     state[3] = fbk;
-
-    if (j == 6ul) {
-      j = 0ul;
-    }
   }
 #elif defined FBK_128
   const size_t itr_cnt = rounds >> 7;

--- a/include/tinyjambu.hpp
+++ b/include/tinyjambu.hpp
@@ -122,7 +122,7 @@ process_associated_data(
 
     uint32_t word = 0u;
     for (size_t i = 0; i < take; i++) {
-      word |= static_cast<uint32_t>(data[b_off + i] << (i << 3));
+      word |= static_cast<uint32_t>(data[b_off + i]) << (i << 3);
     }
 
     state[3] ^= word;
@@ -165,7 +165,7 @@ process_plain_text(
 
     uint32_t word = 0u;
     for (size_t i = 0; i < take; i++) {
-      word |= static_cast<uint32_t>(text[b_off + i] << (i << 3));
+      word |= static_cast<uint32_t>(text[b_off + i]) << (i << 3);
     }
 
     state[3] ^= word;
@@ -214,14 +214,13 @@ process_cipher_text(
 
     uint32_t word = 0u;
     for (size_t i = 0; i < take; i++) {
-      word |= static_cast<uint32_t>(cipher[b_off + i] << (i << 3));
+      word |= static_cast<uint32_t>(cipher[b_off + i]) << (i << 3);
     }
 
     const uint32_t dec = state[2] ^ word;
 
-    for (size_t i = 0; i < take; i++) {
-      state[3] ^= dec & (0xffu << (i << 3));
-    }
+    const uint32_t mask = 0xffffffffu >> ((4ul - take) << 3);
+    state[3] ^= (dec & mask);
 
     for (size_t i = 0; i < take; i++) {
       text[b_off + i] = static_cast<uint8_t>(dec >> (i << 3));

--- a/include/tinyjambu_128.hpp
+++ b/include/tinyjambu_128.hpp
@@ -28,6 +28,9 @@ encrypt(const uint8_t* const __restrict key,   // 128 -bit secret key
 
 #if defined __clang__
 #pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC ivdep
+#pragma GCC unroll 4
 #endif
   for (size_t i = 0; i < 4; i++) {
     key_[i] = from_le_bytes(key + (i << 2));
@@ -67,6 +70,9 @@ decrypt(const uint8_t* const __restrict key,    // 128 -bit secret key
 
 #if defined __clang__
 #pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC ivdep
+#pragma GCC unroll 4
 #endif
   for (size_t i = 0; i < 4; i++) {
     key_[i] = from_le_bytes(key + (i << 2));

--- a/include/tinyjambu_192.hpp
+++ b/include/tinyjambu_192.hpp
@@ -28,6 +28,9 @@ encrypt(const uint8_t* const __restrict key,   // 192 -bit secret key
 
 #if defined __clang__
 #pragma unroll 6
+#elif defined __GNUG__
+#pragma GCC ivdep
+#pragma GCC unroll 6
 #endif
   for (size_t i = 0; i < 6; i++) {
     key_[i] = from_le_bytes(key + (i << 2));
@@ -67,6 +70,9 @@ decrypt(const uint8_t* const __restrict key,    // 192 -bit secret key
 
 #if defined __clang__
 #pragma unroll 6
+#elif defined __GNUG__
+#pragma GCC ivdep
+#pragma GCC unroll 6
 #endif
   for (size_t i = 0; i < 6; i++) {
     key_[i] = from_le_bytes(key + (i << 2));

--- a/include/tinyjambu_256.hpp
+++ b/include/tinyjambu_256.hpp
@@ -27,7 +27,10 @@ encrypt(const uint8_t* const __restrict key,   // 256 -bit secret key
   uint32_t key_[8] = { 0u };
 
 #if defined __clang__
-#pragma unroll 8
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC ivdep
+#pragma GCC unroll 4
 #endif
   for (size_t i = 0; i < 8; i++) {
     key_[i] = from_le_bytes(key + (i << 2));
@@ -66,7 +69,10 @@ decrypt(const uint8_t* const __restrict key,    // 256 -bit secret key
   uint8_t tag_[8] = { 0u };
 
 #if defined __clang__
-#pragma unroll 8
+#pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC ivdep
+#pragma GCC unroll 4
 #endif
   for (size_t i = 0; i < 8; i++) {
     key_[i] = from_le_bytes(key + (i << 2));

--- a/include/utils.hpp
+++ b/include/utils.hpp
@@ -24,6 +24,9 @@ to_le_bytes(const uint32_t word, uint8_t* const bytes)
 {
 #if defined __clang__
 #pragma unroll 4
+#elif defined __GNUG__
+#pragma GCC ivdep
+#pragma GCC unroll 4
 #endif
   for (size_t i = 0; i < 4; i++) {
     bytes[i] = static_cast<uint8_t>(word >> (i << 3));


### PR DESCRIPTION
- Using C++20 feature for evaluating which branch to take ( using `std::is_constant_evaluated` ) at compile-time
- As few branches/ loops as possible ( moving towards branchless code )
- GCC, Clang loop optimization by unrolling loops


With all these, seeing ~25x speedup when compiled with GCC. See benchmark results on ARM Cortex A72 [here](https://github.com/itzmeanjan/tinyjambu/commit/e5829fc65d9bf52560e38721982f53fa8bf26ab6?short_path=b335630#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5). 