### PR TITLE
Compute 64 Feedback Bits/ Iteration

### DIFF
--- a/.github/workflows/test_ci.yml
+++ b/.github/workflows/test_ci.yml
@@ -21,9 +21,7 @@ jobs:
       run: python3 -m pip install -r wrapper/python/requirements.txt --user
     - name: Execute Tests ( 32 feedback bits in parallel )
       run: FBK=32 make
-    - name: Cleanup
-      run: make clean
+    - name: Execute Tests ( 64 feedback bits in parallel )
+      run: FBK=64 make
     - name: Execute Tests ( 128 feedback bits in parallel )
       run: FBK=128 make
-    - name: Cleanup
-      run: make clean

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,11 @@ IFLAGS = -I ./include
 #
 # or
 #
-# `FBK=128 make` // computes 128 feedback bits in-parallel
+# `FBK=64 make` // computes 64 feedback bits per iteration
+#
+# or
+#
+# `FBK=128 make` // computes 128 feedback bits per iteration
 #
 # Note :
 #

--- a/README.md
+++ b/README.md
@@ -112,6 +112,7 @@ Issue following command(s) to run test cases on all variants of TinyJambu
 
 ```bash
 FBK=32 make   # 32 feedback bits in-parallel
+FBK=64 make   # 2x32 feedback bits per iteration
 FBK=128 make  # 4x32 feedback bits per iteration
 ```
 
@@ -127,8 +128,8 @@ Find micro-benchmarking ( using `google-benchmark` ) results [here](./bench/READ
 
 I've written following example programs which demonstrate use of TinyJambu-{128, 192, 256} C++ API
 
-- [TinyJambu-128](https://github.com/itzmeanjan/tinyjambu/blob/dc631cd/example/tinyjambu_128.cpp)
-- [TinyJambu-193](https://github.com/itzmeanjan/tinyjambu/blob/dc631cd/example/tinyjambu_193.cpp)
-- [TinyJambu-256](https://github.com/itzmeanjan/tinyjambu/blob/dc631cd/example/tinyjambu_256.cpp)
+- [TinyJambu-128](./example/tinyjambu_128.cpp)
+- [TinyJambu-193](./example/tinyjambu_192.cpp)
+- [TinyJambu-256](./example/tinyjambu_256.cpp)
 
 You may also want to use Python API of `tinyjambu`, consider checking [here](https://github.com/itzmeanjan/tinyjambu/blob/1082f55/wrapper/python/example.py) for usage example.

--- a/bench/README.md
+++ b/bench/README.md
@@ -5,12 +5,14 @@ For benchmarking TinyJambu-{128, 192, 256} authenticated encryption/ verified de
 ```bash
 FBK=32 make benchmark
 # or
+FBK=64 make benchmark
+# or
 FBK=128 make benchmark
 ```
 
 > **Warning** Because most of the CPUs employ dynamic frequency boosting technique, when benchmarking, you should disable CPU frequency scaling by following [this](https://github.com/google/benchmark/blob/60b16f1/docs/user_guide.md#disabling-cpu-frequency-scaling) guide.
 
-> **Note** Following benchmark results were collected by issuing `make benchmark` i.e. which by default computes 32 feedback bits in parallel. One may also wish to benchmark by issuing `FBK=128 make benchmark`, which computes 128 feedback bits per iteration.
+> **Note** Following benchmark results were collected by issuing `make benchmark` i.e. which by default computes 32 feedback bits in parallel. One may also wish to benchmark by issuing `FBK={64,128} make benchmark`, which computes {64, 128} feedback bits per iteration.
 
 ### On Intel(R) Core(TM) i5-8279U CPU @ 2.40GHz ( compiled using Clang )
 


### PR DESCRIPTION
One can define `FBK_64` for triggering compilation of code block where 64 feedback bits are computed per iteration round i.e. 32 of them are computed in parallel.

For testing issue

```bash
FBK=64 make
```

For benchmark issue

```bash
FBK=64 make benchmark
```